### PR TITLE
feat(web): add start route with trip criteria form

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,35 +1,13 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { Routes, Route, Navigate } from 'react-router-dom'
+import Start from './routes/start'
+import Discover from './routes/discover'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <Routes>
+      <Route path="/" element={<Navigate to="/start" replace />} />
+      <Route path="/start" element={<Start />} />
+      <Route path="/discover" element={<Discover />} />
+    </Routes>
   )
 }
-
-export default App

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,12 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
-import './styles/globals.css';
-
+import './styles/globals.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -1,0 +1,8 @@
+import { useLocation } from 'react-router-dom'
+
+export default function Discover() {
+  const { state } = useLocation() as { state: unknown }
+  return (
+    <pre className="p-4">{JSON.stringify(state, null, 2)}</pre>
+  )
+}

--- a/apps/web/src/routes/start.tsx
+++ b/apps/web/src/routes/start.tsx
@@ -1,0 +1,84 @@
+import type { FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTripCriteria } from '../stores/tripCriteria'
+
+const cityOptions = ['Paris', 'Tokyo', 'New York', 'London']
+const companionOptions = ['Solo', 'Partner', 'Family', 'Friends']
+
+export default function Start() {
+  const navigate = useNavigate()
+  const {
+    city,
+    setCity,
+    startDate,
+    setStartDate,
+    nights,
+    setNights,
+    companions,
+    toggleCompanion,
+  } = useTripCriteria()
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    const criteria = { city, startDate, nights, companions }
+    navigate('/discover', { state: criteria })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+      <div>
+        <label className="block mb-1">City</label>
+        <input
+          list="cities"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+          className="border p-2"
+        />
+        <datalist id="cities">
+          {cityOptions.map((c) => (
+            <option key={c} value={c} />
+          ))}
+        </datalist>
+      </div>
+
+      <div>
+        <label className="block mb-1">Start date</label>
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="border p-2"
+        />
+      </div>
+
+      <div>
+        <label className="block mb-1">Nights</label>
+        <input
+          type="number"
+          min={1}
+          value={nights}
+          onChange={(e) => setNights(Number(e.target.value))}
+          className="border p-2"
+        />
+      </div>
+
+      <div className="flex gap-2 flex-wrap">
+        {companionOptions.map((c) => (
+          <label key={c} className="cursor-pointer">
+            <input
+              type="checkbox"
+              checked={companions.includes(c)}
+              onChange={() => toggleCompanion(c)}
+              className="mr-1"
+            />
+            {c}
+          </label>
+        ))}
+      </div>
+
+      <button type="submit" className="bg-blue-500 text-white p-2 rounded">
+        Discover
+      </button>
+    </form>
+  )
+}

--- a/apps/web/src/stores/tripCriteria.ts
+++ b/apps/web/src/stores/tripCriteria.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+
+interface TripCriteriaState {
+  city: string
+  startDate: string
+  nights: number
+  companions: string[]
+  setCity: (city: string) => void
+  setStartDate: (date: string) => void
+  setNights: (nights: number) => void
+  toggleCompanion: (companion: string) => void
+}
+
+export const useTripCriteria = create<TripCriteriaState>((set) => ({
+  city: '',
+  startDate: '',
+  nights: 1,
+  companions: [],
+  setCity: (city) => set({ city }),
+  setStartDate: (date) => set({ startDate: date }),
+  setNights: (nights) => set({ nights }),
+  toggleCompanion: (companion) =>
+    set((state) => ({
+      companions: state.companions.includes(companion)
+        ? state.companions.filter((c) => c !== companion)
+        : [...state.companions, companion],
+    })),
+}))


### PR DESCRIPTION
## Summary
- add React Router setup and start/discover routes
- introduce trip criteria Zustand store
- implement start form to collect trip details and navigate with router state

## Testing
- `npm test` (fails: Missing script)
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run build`


------
https://chatgpt.com/codex/tasks/task_e_68abd51e45748328b896ac2c9561efd9