### PR TITLE
feat: add discover route with swipe deck

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,34 +1,14 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import Discover from './routes/discover'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <BrowserRouter>
+      <Routes>
+        <Route path='/' element={<Discover />} />
+        <Route path='/discover' element={<Discover />} />
+      </Routes>
+    </BrowserRouter>
   )
 }
 

--- a/apps/web/src/api/suggestions.ts
+++ b/apps/web/src/api/suggestions.ts
@@ -1,0 +1,14 @@
+export interface Suggestion {
+  id: number
+  title: string
+  description: string
+}
+
+export async function fetchSuggestions(_criteria: Record<string, unknown>): Promise<Suggestion[]> {
+  void _criteria
+  return [
+    { id: 1, title: 'Museum Visit', description: 'Explore the city museum.' },
+    { id: 2, title: 'Local Cafe', description: 'Try coffee at the local cafe.' },
+    { id: 3, title: 'City Park', description: 'Take a walk in the park.' },
+  ]
+}

--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+import { fetchSuggestions, type Suggestion } from '../api/suggestions'
+import { useItineraryStore } from '../stores/itineraryStore'
+
+export default function Discover() {
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+  const [index, setIndex] = useState(0)
+  const [startX, setStartX] = useState<number | null>(null)
+  const { addLike, addAdd, likes, adds } = useItineraryStore()
+
+  useEffect(() => {
+    fetchSuggestions({}).then(setSuggestions)
+  }, [])
+
+  const current = suggestions[index]
+  const next = () => setIndex((i) => i + 1)
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setStartX(e.changedTouches[0].clientX)
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (startX === null) return
+    const diff = e.changedTouches[0].clientX - startX
+    if (diff > 50) {
+      addLike()
+      next()
+    } else if (diff < -50) {
+      next()
+    }
+    setStartX(null)
+  }
+
+  const handleAdd = () => {
+    addAdd()
+    next()
+  }
+
+  const canBuild = likes >= 5 || adds >= 3
+
+  return (
+    <div className='p-4'>
+      {current ? (
+        <div
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+          className='border p-4 rounded'
+        >
+          <h2 className='text-lg font-bold'>{current.title}</h2>
+          <p className='mt-2'>{current.description}</p>
+          <button
+            className='mt-4 px-4 py-2 bg-blue-500 text-white rounded'
+            onClick={handleAdd}
+          >
+            Add to Itinerary
+          </button>
+        </div>
+      ) : (
+        <p>No more suggestions</p>
+      )}
+      <button
+        className='mt-6 px-4 py-2 bg-green-500 text-white rounded disabled:opacity-50'
+        disabled={!canBuild}
+      >
+        Build Itinerary
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/stores/itineraryStore.ts
+++ b/apps/web/src/stores/itineraryStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+
+interface ItineraryState {
+  likes: number
+  adds: number
+  addLike: () => void
+  addAdd: () => void
+}
+
+export const useItineraryStore = create<ItineraryState>((set) => ({
+  likes: 0,
+  adds: 0,
+  addLike: () => set((state) => ({ likes: state.likes + 1 })),
+  addAdd: () => set((state) => ({ adds: state.adds + 1 })),
+}))


### PR DESCRIPTION
## Summary
- add Discover route with swipeable suggestion cards
- track likes and adds in a zustand itinerary store
- mock fetchSuggestions returning placeholder suggestions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abd51f501c8328b8906c3fa190675e