### PR TITLE
Add draft itinerary route with mock API and store

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,9 +1,11 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import Draft from './routes/draft'
 
-function App() {
+function Home() {
   const [count, setCount] = useState(0)
 
   return (
@@ -32,4 +34,13 @@ function App() {
   )
 }
 
-export default App
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/draft" element={<Draft />} />
+      </Routes>
+    </BrowserRouter>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,30 @@
+export interface CreateDraftItineraryParams {
+  likes: string[]
+  adds: string[]
+  dates: string[]
+  mood: string
+}
+
+export interface ItineraryEvent {
+  id: string
+  name: string
+}
+
+export interface ItineraryDay {
+  date: string
+  events: ItineraryEvent[]
+}
+
+export async function createDraftItinerary(
+  params: CreateDraftItineraryParams,
+): Promise<ItineraryDay[]> {
+  const { dates } = params
+  // Mock implementation returning simple events for each date
+  return dates.map((date, idx) => ({
+    date,
+    events: [
+      { id: `${idx}-1`, name: `Event A on ${date}` },
+      { id: `${idx}-2`, name: `Event B on ${date}` },
+    ],
+  }))
+}

--- a/apps/web/src/routes/draft.tsx
+++ b/apps/web/src/routes/draft.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import { createDraftItinerary } from '../lib/api'
+import { useItineraryStore } from '../stores/itineraryStore'
+
+export default function Draft() {
+  const { days, setDays, lockDay } = useItineraryStore()
+  const [tab, setTab] = useState<'calendar' | 'list' | 'map'>('calendar')
+
+  useEffect(() => {
+    async function load() {
+      if (days.length === 0) {
+        const data = await createDraftItinerary({
+          likes: [],
+          adds: [],
+          dates: ['2025-01-01', '2025-01-02'],
+          mood: 'chill',
+        })
+        setDays(data)
+      }
+    }
+    load()
+  }, [days, setDays])
+
+  const handleShuffle = async () => {
+    const current = useItineraryStore.getState().days
+    const data = await createDraftItinerary({
+      likes: [],
+      adds: [],
+      dates: current.map((d) => d.date),
+      mood: 'chill',
+    })
+    const merged = current.map((d, i) => (d.locked ? d : data[i]))
+    setDays(merged)
+  }
+
+  const handleSave = () => {
+    // Placeholder for save logic
+    console.log('Saving trip', days)
+  }
+
+  return (
+    <div>
+      <div>
+        <button onClick={() => setTab('calendar')}>Calendar</button>
+        <button onClick={() => setTab('list')}>List</button>
+        <button onClick={() => setTab('map')}>Map</button>
+      </div>
+
+      {tab === 'calendar' && <div>Calendar View</div>}
+      {tab === 'map' && <div>Map View</div>}
+      {tab === 'list' && (
+        <div>
+          {days.map((day, idx) => (
+            <div key={day.date}>
+              <h3>{day.date}</h3>
+              <ul>
+                {day.events.map((ev) => (
+                  <li key={ev.id}>{ev.name}</li>
+                ))}
+              </ul>
+              <button disabled={day.locked} onClick={() => lockDay(idx)}>
+                {day.locked ? 'Accepted' : 'Accept Day'}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div>
+        <button onClick={handleShuffle}>Magic Shuffle</button>
+        <button onClick={handleSave}>Save Trip</button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/stores/itineraryStore.ts
+++ b/apps/web/src/stores/itineraryStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand'
+import type { ItineraryDay } from '../lib/api'
+
+type DayWithLock = ItineraryDay & { locked?: boolean }
+
+interface ItineraryState {
+  days: DayWithLock[]
+  setDays: (days: DayWithLock[]) => void
+  lockDay: (index: number) => void
+}
+
+export const useItineraryStore = create<ItineraryState>((set) => ({
+  days: [],
+  setDays: (days) => set({ days }),
+  lockDay: (index) =>
+    set((state) => {
+      const updated = state.days.map((d, i) =>
+        i === index ? { ...d, locked: true } : d,
+      )
+      return { days: updated }
+    }),
+}))


### PR DESCRIPTION
## Summary
- add mock API for creating draft itineraries
- track itinerary days in zustand store
- introduce Draft route with tabs and controls
- wire router to include Draft route

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abd5202314832897ec155b51e9e9eb