### PR TITLE
Add event detail view and collaboration modal with AI optimize

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,33 +1,42 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import EventDetail from './components/EventDetail'
+import InviteCollaboratorsModal from './components/InviteCollaboratorsModal'
+import { createDraftItinerary } from './api'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [currentDay, setCurrentDay] = useState(1)
+  const [inviteOpen, setInviteOpen] = useState(false)
+
+  const event = {
+    description: 'Visit the art museum',
+    location: 'Downtown Museum',
+    contact: 'info@museum.com',
+    duration: '2 hours',
+    suggestions: ['City Gallery', 'Historical Tour'],
+  }
+
+  const handleOptimize = () => {
+    createDraftItinerary(currentDay)
+  }
 
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <label>
+        Day:
+        <input
+          type="number"
+          value={currentDay}
+          onChange={(e) => setCurrentDay(Number(e.target.value))}
+        />
+      </label>
+      <EventDetail {...event} />
+      <button onClick={handleOptimize}>AI optimize</button>
+      <button onClick={() => setInviteOpen(true)}>Invite collaborators</button>
+      <InviteCollaboratorsModal
+        isOpen={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+      />
     </>
   )
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,0 +1,11 @@
+export async function createDraftItinerary(day: number) {
+  // Stubbed API call
+  console.log('createDraftItinerary for day', day)
+  return { success: true }
+}
+
+export async function sendInvite(email: string, permission: string) {
+  // Stubbed API call
+  console.log('sendInvite', email, permission)
+  return { success: true }
+}

--- a/apps/web/src/components/EventDetail.tsx
+++ b/apps/web/src/components/EventDetail.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+interface EventDetailProps {
+  description: string
+  location: string
+  contact: string
+  duration: string
+  suggestions: string[]
+}
+
+const EventDetail: React.FC<EventDetailProps> = ({
+  description,
+  location,
+  contact,
+  duration,
+  suggestions,
+}) => {
+  return (
+    <div className="event-detail">
+      <h2>Event Details</h2>
+      <p>
+        <strong>Description:</strong> {description}
+      </p>
+      <p>
+        <strong>Location:</strong> {location}
+      </p>
+      <p>
+        <strong>Contact:</strong> {contact}
+      </p>
+      <p>
+        <strong>Duration:</strong> {duration}
+      </p>
+      {suggestions.length > 0 && (
+        <div>
+          <h3>Similar Suggestions</h3>
+          <ul>
+            {suggestions.map((s, idx) => (
+              <li key={idx}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default EventDetail

--- a/apps/web/src/components/InviteCollaboratorsModal.tsx
+++ b/apps/web/src/components/InviteCollaboratorsModal.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import { sendInvite } from '../api'
+
+interface InviteCollaboratorsModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const InviteCollaboratorsModal: React.FC<InviteCollaboratorsModalProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const [email, setEmail] = useState('')
+  const [permission, setPermission] = useState('view')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await sendInvite(email, permission)
+    setEmail('')
+    setPermission('view')
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <h2>Invite Collaborators</h2>
+        <form onSubmit={handleSubmit}>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            required
+          />
+          <select
+            value={permission}
+            onChange={(e) => setPermission(e.target.value)}
+          >
+            <option value="view">View</option>
+            <option value="edit">Edit</option>
+          </select>
+          <button type="submit">Send Invite</button>
+          <button type="button" onClick={onClose}>
+            Cancel
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default InviteCollaboratorsModal


### PR DESCRIPTION
## Summary
- show event details including description, location, contact, duration, and suggestions
- add AI optimize button to re-run createDraftItinerary for the selected day
- provide Invite collaborators modal with email and permission options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abd5221e748328a2be734f6e1aefd1