### PR TITLE
Add profile and trip pages with mock save flow

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,35 +1,16 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { Routes, Route } from 'react-router-dom';
+import DraftPage from './pages/DraftPage';
+import ProfilePage from './pages/ProfilePage';
+import TripPage from './pages/TripPage';
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <Routes>
+      <Route path="/" element={<DraftPage />} />
+      <Route path="/profile" element={<ProfilePage />} />
+      <Route path="/trip/:id" element={<TripPage />} />
+    </Routes>
+  );
 }
 
-export default App
+export default App;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,0 +1,20 @@
+export interface Trip {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export async function saveTrip(trip: Trip): Promise<void> {
+  // mock API call, resolves after short delay
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  console.log('Trip saved', trip);
+}
+
+export function getTrip(id: string): Trip {
+  // mock fetch of trip
+  return {
+    id,
+    title: `Trip ${id}`,
+    description: 'A wonderful journey awaits you.',
+  };
+}

--- a/apps/web/src/components/ToastProvider.tsx
+++ b/apps/web/src/components/ToastProvider.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import * as Toast from '@radix-ui/react-toast';
+
+interface ToastContextValue {
+  toast: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({ toast: () => {} });
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const toast = (msg: string) => {
+    setMessage(msg);
+    setOpen(true);
+  };
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      <Toast.Provider swipeDirection="right">
+        {children}
+        <Toast.Root open={open} onOpenChange={setOpen} className="bg-black text-white p-4 rounded">
+          <Toast.Title>{message}</Toast.Title>
+        </Toast.Root>
+        <Toast.Viewport className="fixed top-0 right-0 p-4" />
+      </Toast.Provider>
+    </ToastContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/apps/web/src/components/TripDraft.tsx
+++ b/apps/web/src/components/TripDraft.tsx
@@ -1,0 +1,24 @@
+import { Trip } from '../api';
+
+interface Props {
+  trip: Trip;
+  readOnly?: boolean;
+  onSave?: () => void;
+}
+
+export function TripDraft({ trip, readOnly, onSave }: Props) {
+  return (
+    <div className="p-4 border rounded">
+      <h2 className="text-xl font-bold">{trip.title}</h2>
+      <p className="mt-2">{trip.description}</p>
+      {!readOnly && (
+        <button
+          className="mt-4 px-4 py-2 bg-blue-500 text-white rounded"
+          onClick={onSave}
+        >
+          Save Trip
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,12 +1,17 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import './index.css';
+import App from './App.tsx';
 import './styles/globals.css';
-
+import { ToastProvider } from './components/ToastProvider';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <ToastProvider>
+        <App />
+      </ToastProvider>
+    </BrowserRouter>
   </StrictMode>,
-)
+);

--- a/apps/web/src/pages/DraftPage.tsx
+++ b/apps/web/src/pages/DraftPage.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+import { getTrip, saveTrip } from '../api';
+import { TripDraft } from '../components/TripDraft';
+import { useToast } from '../components/ToastProvider';
+
+export default function DraftPage() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const trip = getTrip('draft');
+
+  const handleSave = async () => {
+    await saveTrip(trip);
+    toast('Trip saved');
+    navigate('/profile');
+  };
+
+  return (
+    <div className="p-4">
+      <TripDraft trip={trip} onSave={handleSave} />
+    </div>
+  );
+}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,0 +1,43 @@
+import { Trip, getTrip } from '../api';
+
+const myTrips: Trip[] = [getTrip('1'), getTrip('2'), getTrip('3')];
+const suggestedTrips: Trip[] = [getTrip('4'), getTrip('5'), getTrip('6')];
+
+export default function ProfilePage() {
+  return (
+    <div className="p-4 space-y-6">
+      <div className="flex items-center space-x-4">
+        <img
+          src="https://i.pravatar.cc/100"
+          alt="avatar"
+          className="rounded-full w-24 h-24"
+        />
+        <p>Traveler and adventurer.</p>
+      </div>
+      <section>
+        <h2 className="text-lg font-bold mb-2">My Trips</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {myTrips.map((t) => (
+            <div key={t.id} className="border p-2 rounded">
+              <h3 className="font-semibold">{t.title}</h3>
+              <p className="text-sm">{t.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section>
+        <h2 className="text-lg font-bold mb-2">Suggested Trips</h2>
+        <div className="overflow-x-auto">
+          <div className="flex space-x-4">
+            {suggestedTrips.map((t) => (
+              <div key={t.id} className="border p-2 rounded min-w-[200px]">
+                <h3 className="font-semibold">{t.title}</h3>
+                <p className="text-sm">{t.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/pages/TripPage.tsx
+++ b/apps/web/src/pages/TripPage.tsx
@@ -1,0 +1,23 @@
+import { useParams } from 'react-router-dom';
+import { getTrip } from '../api';
+import { TripDraft } from '../components/TripDraft';
+
+export default function TripPage() {
+  const { id } = useParams<{ id: string }>();
+  const trip = getTrip(id ?? '');
+
+  return (
+    <div className="p-4 space-y-4">
+      <TripDraft trip={trip} readOnly />
+      <div>
+        <p className="font-semibold">Shareable link:</p>
+        <input
+          type="text"
+          readOnly
+          value={window.location.href}
+          className="w-full border p-2"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add mock trip API and toast provider
- create profile page, trip page, and draft page with save flow
- wire up router for profile and shareable trip routes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abd523d0908328be628f47b7b0091d