### PR TITLE
feat: scaffold trip service layer and env config

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,3 @@
+VITE_API_BASE_URL=https://api.example.com
+VITE_AI_API_KEY=demo-key
+VITE_STORAGE_ENDPOINT=https://storage.example.com

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,9 +2,11 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import { useTrips } from './lib/queries'
 
 function App() {
   const [count, setCount] = useState(0)
+  const { data: trips } = useTrips()
 
   return (
     <>
@@ -28,6 +30,7 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
+      <pre>{JSON.stringify(trips, null, 2)}</pre>
     </>
   )
 }

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -1,0 +1,3 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+export const AI_API_KEY = import.meta.env.VITE_AI_API_KEY;
+export const STORAGE_ENDPOINT = import.meta.env.VITE_STORAGE_ENDPOINT;

--- a/apps/web/src/lib/mocks/ai.ts
+++ b/apps/web/src/lib/mocks/ai.ts
@@ -1,0 +1,10 @@
+import type { Suggestion } from '../types';
+
+export async function mockFetchSuggestions(prompt: string): Promise<Suggestion[]> {
+  return [
+    {
+      id: '1',
+      text: `Mock suggestion for ${prompt}`,
+    },
+  ];
+}

--- a/apps/web/src/lib/mocks/storage.ts
+++ b/apps/web/src/lib/mocks/storage.ts
@@ -1,0 +1,22 @@
+import type { Trip } from '../types';
+
+const trips: Trip[] = [
+  {
+    id: 't1',
+    itinerary: {
+      id: 'i1',
+      suggestions: [
+        { id: 's1', text: 'Mock trip suggestion' },
+      ],
+    },
+  },
+];
+
+export async function mockGetTrips(): Promise<Trip[]> {
+  return trips;
+}
+
+export async function mockSaveTrip(trip: Trip): Promise<Trip> {
+  trips.push(trip);
+  return trip;
+}

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchSuggestions } from './services/ai';
+import { getTrips, saveTrip } from './services/storage';
+import type { Trip } from './types';
+
+export function useSuggestions(prompt: string) {
+  return useQuery({
+    queryKey: ['suggestions', prompt],
+    queryFn: () => fetchSuggestions(prompt),
+    enabled: !!prompt,
+  });
+}
+
+export function useTrips() {
+  return useQuery({
+    queryKey: ['trips'],
+    queryFn: getTrips,
+  });
+}
+
+export function useSaveTrip() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (trip: Trip) => saveTrip(trip),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['trips'] });
+    },
+  });
+}

--- a/apps/web/src/lib/services/ai.ts
+++ b/apps/web/src/lib/services/ai.ts
@@ -1,0 +1,10 @@
+import type { Suggestion } from '../types';
+import { mockFetchSuggestions } from '../mocks/ai';
+import { API_BASE_URL, AI_API_KEY } from '../config';
+
+export async function fetchSuggestions(prompt: string): Promise<Suggestion[]> {
+  // TODO: replace mock implementation with real AI API call
+  void API_BASE_URL; // referenced to show usage
+  void AI_API_KEY;
+  return mockFetchSuggestions(prompt);
+}

--- a/apps/web/src/lib/services/storage.ts
+++ b/apps/web/src/lib/services/storage.ts
@@ -1,0 +1,14 @@
+import type { Trip } from '../types';
+import { mockGetTrips, mockSaveTrip } from '../mocks/storage';
+import { STORAGE_ENDPOINT } from '../config';
+
+export async function getTrips(): Promise<Trip[]> {
+  // TODO: replace mock implementation with real storage API call
+  void STORAGE_ENDPOINT;
+  return mockGetTrips();
+}
+
+export async function saveTrip(trip: Trip): Promise<Trip> {
+  // TODO: replace mock implementation with real storage API call
+  return mockSaveTrip(trip);
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,0 +1,14 @@
+export interface Suggestion {
+  id: string;
+  text: string;
+}
+
+export interface Itinerary {
+  id: string;
+  suggestions: Suggestion[];
+}
+
+export interface Trip {
+  id: string;
+  itinerary: Itinerary;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,12 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
 import './styles/globals.css';
 
+const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string;
+  readonly VITE_AI_API_KEY: string;
+  readonly VITE_STORAGE_ENDPOINT: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- define Suggestion, Itinerary, and Trip interfaces and expose React Query hooks
- add AI and storage service stubs with isolated mocks and env-driven config
- wrap app with QueryClientProvider and document required Vite env variables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run build`


------
https://chatgpt.com/codex/tasks/task_e_68abd52635a08328b1e9470851760078