### PR TITLE
Add likes and adds counters to itinerary store

### DIFF
--- a/apps/web/src/stores/itineraryStore.ts
+++ b/apps/web/src/stores/itineraryStore.ts
@@ -5,12 +5,18 @@ type DayWithLock = ItineraryDay & { locked?: boolean }
 
 interface ItineraryState {
   days: DayWithLock[]
+  likes: number
+  adds: number
   setDays: (days: DayWithLock[]) => void
-  lockDay: (index: number) => voi
+  lockDay: (index: number) => void
+  addLike: () => void
+  addAdd: () => void
 }
 
 export const useItineraryStore = create<ItineraryState>((set) => ({
   days: [],
+  likes: 0,
+  adds: 0,
   setDays: (days) => set({ days }),
   lockDay: (index) =>
     set((state) => {
@@ -19,4 +25,6 @@ export const useItineraryStore = create<ItineraryState>((set) => ({
       )
       return { days: updated }
     }),
+  addLike: () => set((state) => ({ likes: state.likes + 1 })),
+  addAdd: () => set((state) => ({ adds: state.adds + 1 })),
 }))


### PR DESCRIPTION
## Summary
- extend itinerary store with likes and adds counters
- add helper actions to increment likes and adds
- correct lockDay signature to return void

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/stores/itineraryStore.ts`


------
https://chatgpt.com/codex/tasks/task_e_68abe09c1f208328a1f06af7559eadff