### PR TITLE
Add itinerary builder navigation from discover page

### DIFF
--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react'
 import { fetchSuggestions, type Suggestion } from '../api/suggestions'
 import { useItineraryStore } from '../stores/itineraryStore'
+import { createDraftItinerary } from '../lib/api'
+import { useNavigate } from 'react-router-dom'
 
 export default function Discover() {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
   const [index, setIndex] = useState(0)
   const [startX, setStartX] = useState<number | null>(null)
-  const { addLike, addAdd, likes, adds } = useItineraryStore()
+  const { addLike, addAdd, likes, adds, setDays } = useItineraryStore()
+  const navigate = useNavigate()
 
   useEffect(() => {
     fetchSuggestions({}).then(setSuggestions)
@@ -36,7 +39,19 @@ export default function Discover() {
     next()
   }
 
-  const canBuild = likes >= 5 || adds >= 3
+  const buildItinerary = async () => {
+    const days = await createDraftItinerary({
+      likes,
+      adds,
+      dates: ['2025-01-01', '2025-01-02'],
+      mood: 'chill',
+    })
+    setDays(days)
+    setIndex(0)
+    navigate('/draft')
+  }
+
+  const canBuild = likes.length >= 5 || adds.length >= 3
 
   return (
     <div className='p-4'>
@@ -61,6 +76,7 @@ export default function Discover() {
       <button
         className='mt-6 px-4 py-2 bg-green-500 text-white rounded disabled:opacity-50'
         disabled={!canBuild}
+        onClick={buildItinerary}
       >
         Build Itinerary
       </button>


### PR DESCRIPTION
## Summary
- Build itinerary on Discover page by calling API and navigating to draft
- Reset suggestion index and store itinerary days after building

## Testing
- `npm test` *(fails: Missing script "test" )*
- `(cd apps/web && npm test)` *(fails: Missing script "test" )*
- `(cd apps/web && npm run lint)` *(fails: Parsing error in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68abe0a5c2088328b5653807b068ed16