### PR TITLE
feat: add flexible date and city autocomplete

### DIFF
--- a/apps/web/src/stores/tripCriteria.ts
+++ b/apps/web/src/stores/tripCriteria.ts
@@ -2,22 +2,34 @@ import { create } from 'zustand'
 
 interface TripCriteriaState {
   city: string
+  dateMode: 'range' | 'flex'
   startDate: string
+  endDate: string
+  month: string
   nights: number
   companions: string[]
   setCity: (city: string) => void
+  setDateMode: (mode: 'range' | 'flex') => void
   setStartDate: (date: string) => void
+  setEndDate: (date: string) => void
+  setMonth: (month: string) => void
   setNights: (nights: number) => void
   toggleCompanion: (companion: string) => void
 }
 
 export const useTripCriteria = create<TripCriteriaState>((set) => ({
   city: '',
+  dateMode: 'range',
   startDate: '',
+  endDate: '',
+  month: '',
   nights: 1,
   companions: [],
   setCity: (city) => set({ city }),
+  setDateMode: (mode) => set({ dateMode: mode }),
   setStartDate: (date) => set({ startDate: date }),
+  setEndDate: (date) => set({ endDate: date }),
+  setMonth: (month) => set({ month }),
   setNights: (nights) => set({ nights }),
   toggleCompanion: (companion) =>
     set((state) => ({


### PR DESCRIPTION
## Summary
- replace city datalist with async city autocomplete using mock `/cities` endpoint
- support exact dates or month + nights with persisted criteria
- validate trip details before navigating to Discover

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68abe0a8a1ec8328b1a0787ff10de128