### PR TITLE
docs: expand README with overview and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # Meguru-discovery-a24
-# Meguru-discovery-a24
-# Meguru-discovery-a24
+
+The A24 travel planner is a conceptual web app that helps travelers craft cinematic journeys by exploring destinations inspired by A24 films. It provides a modern React and Vite-based interface for browsing locations, building itineraries, and uncovering hidden gems with a film enthusiast's touch.
+
+## Getting Started
+
+1. Clone this repository and navigate into it.
+2. Install dependencies and start the development server:
+
+   ```bash
+   cd apps/web
+   npm install
+   npm run dev
+   ```
+
+   The app will be available at the URL printed in the terminal (typically `http://localhost:5173`).
+
+## Project Structure
+
+```
+.
+├── apps
+│   └── web/          # React + Vite front-end
+├── package.json
+└── README.md
+```
+
+## Future Work
+
+- Connect to real travel APIs for live data
+- Expand to include mobile and server components
+- Add collaborative trip planning features


### PR DESCRIPTION
## Summary
- add project overview of A24 travel planner concept
- document setup steps and local web app commands
- outline project structure and future work ideas

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abe0b20f9483289f023063d076a68f