### PR TITLE
refactor: share discovery thresholds

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",
@@ -34,6 +35,7 @@
     "tailwindcss": "^4.1.12",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^2.1.1"
   }
 }

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,0 +1,2 @@
+export const MIN_LIKES = 5;
+export const MIN_ADDS = 3;

--- a/apps/web/src/routes/discover.test.ts
+++ b/apps/web/src/routes/discover.test.ts
@@ -1,0 +1,24 @@
+import { MIN_LIKES, MIN_ADDS } from '../lib/constants'
+
+describe('gating logic', () => {
+  test('allows build when likes meet threshold', () => {
+    const likes = MIN_LIKES
+    const adds = 0
+    const canBuild = likes >= MIN_LIKES || adds >= MIN_ADDS
+    expect(canBuild).toBe(true)
+  })
+
+  test('allows build when adds meet threshold', () => {
+    const likes = 0
+    const adds = MIN_ADDS
+    const canBuild = likes >= MIN_LIKES || adds >= MIN_ADDS
+    expect(canBuild).toBe(true)
+  })
+
+  test('disallows build when thresholds not met', () => {
+    const likes = MIN_LIKES - 1
+    const adds = MIN_ADDS - 1
+    const canBuild = likes >= MIN_LIKES || adds >= MIN_ADDS
+    expect(canBuild).toBe(false)
+  })
+})

--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { fetchSuggestions, type Suggestion } from '../api/suggestions'
 import { useItineraryStore } from '../stores/itineraryStore'
+import { MIN_LIKES, MIN_ADDS } from '../lib/constants'
 
 export default function Discover() {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
@@ -36,7 +37,7 @@ export default function Discover() {
     next()
   }
 
-  const canBuild = likes >= 5 || adds >= 3
+  const canBuild = likes >= MIN_LIKES || adds >= MIN_ADDS
 
   return (
     <div className='p-4'>


### PR DESCRIPTION
## Summary
- define shared MIN_LIKES and MIN_ADDS constants
- use discovery constants in routes
- add gating logic unit tests with vitest

## Testing
- `npm install --prefix apps/web` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm test --prefix apps/web` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe0b69ff88328a6f0374d0b47c5fa