### PR TITLE
Use UI Button for itinerary CTA

### DIFF
--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -70,8 +70,8 @@ export default function Discover() {
       ) : (
         <p>No more suggestions</p>
       )}
-      <button
-        className='mt-6 px-4 py-2 bg-green-500 text-white rounded disabled:opacity-50'
+      <Button
+        className='mt-6 disabled:opacity-50'
         disabled={!canBuild}
         onClick={buildItinerary}
       >


### PR DESCRIPTION
## Summary
- replace native CTA with reusable Button component
- keep build itinerary button disabled until ready

## Testing
- `npm test --prefix apps/web` *(fails: vitest not found)*
- `npm install --prefix apps/web` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68abe74a9b208328b0e2f28d208009cd