### PR TITLE
fix sheet className line breaks

### DIFF
--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -7,7 +7,9 @@ interface SheetProps extends HTMLAttributes<HTMLDivElement> {
 export function Sheet({ open = false, className = '', ...props }: SheetProps) {
   return (
     <div
-      className={`fixed left-0 right-0 bottom-0 transform rounded-t-lg bg-cream transition-transform sm:p-6 ${open ? 'translate-y-0' : 'translate-y-full'} ${className}`}
+      className={`fixed left-0 right-0 bottom-0 transform rounded-t-lg bg-cream transition-transform sm:p-6 ${
+        open ? 'translate-y-0' : 'translate-y-full'
+      } ${className}`}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- keep `translate-y-0` contiguous in Sheet component

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: parsing errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68abe75bd6f08328b17ea37b882e470c