### PR TITLE
Simplify App component to router-only routes

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,46 +5,10 @@ import Discover from './routes/discover'
 import Draft from './routes/draft'
 import ProfilePage from './pages/ProfilePage'
 import TripPage from './pages/TripPage'
-import { useState } from 'react'
-import EventDetail from './components/EventDetail'
-import InviteCollaboratorsModal from './components/InviteCollaboratorsModal'
-import { createDraftItinerary } from './lib/services/itinerary'
-import Calendar from './components/Calendar'
-import EventList from './components/EventList'
-import MapView from './components/MapView'
-import { initialEvents, suggestionEvents } from './data'
-import type { EventItem } from './lib/types'
+
 import './App.css'
-import { useTrips } from './lib/queries'
 
 export default function App() {
-  const [currentDay, setCurrentDay] = useState(1)
-  const [inviteOpen, setInviteOpen] = useState(false)
-  const [events, setEvents] = useState<EventItem[]>(initialEvents)
-  const [suggestions, setSuggestions] = useState<EventItem[]>(suggestionEvents)
-
-  const replaceEvent = (id: string, alt: EventItem) => {
-    setEvents((evts) => evts.map((e) => (e.id === id ? { ...alt, alternates: e.alternates } : e)))
-  }
-
-  const addEvent = (e: EventItem) => {
-    setEvents((evts) => [...evts, e])
-    setSuggestions((sugs) => sugs.filter((s) => s.id !== e.id))
-  }
-  const event = {
-    description: 'Visit the art museum',
-    location: 'Downtown Museum',
-    contact: 'info@museum.com',
-    duration: '2 hours',
-    suggestions: ['City Gallery', 'Historical Tour'],
-  }
-
-  const handleOptimize = () => {
-    createDraftItinerary({ likes: [], adds: [], dates: [], mood: 'chill' })
-  }
-  const [count, setCount] = useState(0)
-  const { data: trips } = useTrips()
-
   return (
     <BrowserRouter>
       <Routes>


### PR DESCRIPTION
## Summary
- remove unused imports, state, and helpers from App
- keep only BrowserRouter and core route components

## Testing
- `npm test --prefix apps/web` *(fails: vitest not found and dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68abea29198083288fd004e3b4137a8d