### PR TITLE
Define root route to fix landing page routing error

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -48,6 +48,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <Routes>
+        <Route path="/" element={<Start />} />
         <Route path="/start" element={<Start />} />
         <Route path="/discover" element={<Discover />} />
         <Route path="/draft" element={<Draft />} />


### PR DESCRIPTION
## Summary
- Add root route mapping to the Start page so visiting "/" no longer triggers a missing route error

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68abea1e06548328ae34a01a7806f172