### PR TITLE
feat: add event detail modal and invite sheet

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -6,9 +6,10 @@ interface Props {
   events: EventItem[]
   setEvents: (events: EventItem[]) => void
   onReplace: (id: string, alt: EventItem) => void
+  onSelect?: (e: EventItem) => void
 }
 
-export default function Calendar({ events, setEvents, onReplace }: Props) {
+export default function Calendar({ events, setEvents, onReplace, onSelect }: Props) {
   const [activeId, setActiveId] = useState<string | null>(null)
   const [dragId, setDragId] = useState<string | null>(null)
 
@@ -49,6 +50,7 @@ export default function Calendar({ events, setEvents, onReplace }: Props) {
           handleDragStart={handleDragStart}
           handleDrop={handleDrop}
           onReplace={onReplace}
+          onSelect={onSelect}
         />
       ))}
     </div>
@@ -63,6 +65,7 @@ interface RowProps {
   handleDragStart: (id: string) => void
   handleDrop: (id: string) => void
   onReplace: (id: string, alt: EventItem) => void
+  onSelect?: (e: EventItem) => void
 }
 
 function EventRow({
@@ -73,6 +76,7 @@ function EventRow({
   handleDragStart,
   handleDrop,
   onReplace,
+  onSelect,
 }: RowProps) {
   const longPress = useLongPress(() => setActiveId(e.id))
   return (
@@ -82,6 +86,7 @@ function EventRow({
       onDragOver={(ev) => ev.preventDefault()}
       onDrop={() => handleDrop(e.id)}
       className={`p-2 mb-2 border rounded relative ${conflict ? 'bg-red-200' : 'bg-white'}`}
+      onClick={() => onSelect?.(e)}
       {...longPress}
     >
       <div className="font-medium">{e.title}</div>

--- a/apps/web/src/components/EventDetail.tsx
+++ b/apps/web/src/components/EventDetail.tsx
@@ -1,41 +1,26 @@
 import React from 'react'
+import type { EventItem } from '../lib/types'
 
 interface EventDetailProps {
-  description: string
-  location: string
-  contact: string
-  duration: string
-  suggestions: string[]
+  event: EventItem
 }
 
-const EventDetail: React.FC<EventDetailProps> = ({
-  description,
-  location,
-  contact,
-  duration,
-  suggestions,
-}) => {
+const EventDetail: React.FC<EventDetailProps> = ({ event }) => {
   return (
     <div className="event-detail">
-      <h2>Event Details</h2>
+      <h2>{event.title}</h2>
       <p>
-        <strong>Description:</strong> {description}
+        <strong>Category:</strong> {event.category}
       </p>
       <p>
-        <strong>Location:</strong> {location}
+        <strong>Time:</strong> {event.start / 60}:00 - {event.end / 60}:00
       </p>
-      <p>
-        <strong>Contact:</strong> {contact}
-      </p>
-      <p>
-        <strong>Duration:</strong> {duration}
-      </p>
-      {suggestions.length > 0 && (
+      {event.alternates && event.alternates.length > 0 && (
         <div>
           <h3>Similar Suggestions</h3>
           <ul>
-            {suggestions.map((s, idx) => (
-              <li key={idx}>{s}</li>
+            {event.alternates.map((s) => (
+              <li key={s.id}>{s.title}</li>
             ))}
           </ul>
         </div>

--- a/apps/web/src/components/EventList.tsx
+++ b/apps/web/src/components/EventList.tsx
@@ -4,15 +4,20 @@ import type { EventItem } from '../lib/types'
 interface Props {
   events: EventItem[]
   onReplace: (id: string, alt: EventItem) => void
+  onSelect?: (e: EventItem) => void
 }
 
-export default function EventList({ events, onReplace }: Props) {
+export default function EventList({ events, onReplace, onSelect }: Props) {
   const [openId, setOpenId] = useState<string | null>(null)
   return (
     <div className="w-64 border p-2">
       <h2 className="font-bold mb-2">List</h2>
       {events.map((e) => (
-        <div key={e.id} className="border p-2 mb-2 rounded">
+        <div
+          key={e.id}
+          className="border p-2 mb-2 rounded"
+          onClick={() => onSelect?.(e)}
+        >
           <div className="flex justify-between mb-1">
             <span>{e.title}</span>
             <span className="text-xs bg-gray-200 px-1 rounded">{e.category}</span>
@@ -21,7 +26,10 @@ export default function EventList({ events, onReplace }: Props) {
             <div>
               <button
                 className="text-sm text-blue-600"
-                onClick={() => setOpenId(openId === e.id ? null : e.id)}
+                onClick={(ev) => {
+                  ev.stopPropagation()
+                  setOpenId(openId === e.id ? null : e.id)
+                }}
               >
                 Replace
               </button>
@@ -31,7 +39,8 @@ export default function EventList({ events, onReplace }: Props) {
                     <button
                       key={alt.id}
                       className="block text-left w-full hover:bg-gray-100 px-2 py-1"
-                      onClick={() => {
+                      onClick={(ev) => {
+                        ev.stopPropagation()
                         onReplace(e.id, alt)
                         setOpenId(null)
                       }}

--- a/apps/web/src/components/InviteCollaboratorsModal.tsx
+++ b/apps/web/src/components/InviteCollaboratorsModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { sendInvite } from '../lib/services/invite'
+import { Sheet } from './ui'
 
 interface InviteCollaboratorsModalProps {
   isOpen: boolean
@@ -21,34 +22,36 @@ const InviteCollaboratorsModal: React.FC<InviteCollaboratorsModalProps> = ({
     onClose()
   }
 
-  if (!isOpen) return null
-
   return (
-    <div className="modal">
-      <div className="modal-content">
-        <h2>Invite Collaborators</h2>
-        <form onSubmit={handleSubmit}>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="Email"
-            required
-          />
-          <select
-            value={permission}
-            onChange={(e) => setPermission(e.target.value)}
-          >
-            <option value="view">View</option>
-            <option value="edit">Edit</option>
-          </select>
-          <button type="submit">Send Invite</button>
-          <button type="button" onClick={onClose}>
+    <Sheet open={isOpen} className="p-4 space-y-4">
+      <h2 className="text-lg font-bold">Invite Collaborators</h2>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          required
+          className="w-full border p-2 rounded"
+        />
+        <select
+          value={permission}
+          onChange={(e) => setPermission(e.target.value)}
+          className="w-full border p-2 rounded"
+        >
+          <option value="view">View</option>
+          <option value="edit">Edit</option>
+        </select>
+        <div className="flex gap-2 justify-end">
+          <button type="button" onClick={onClose} className="px-2 py-1 border rounded">
             Cancel
           </button>
-        </form>
-      </div>
-    </div>
+          <button type="submit" className="px-2 py-1 border rounded bg-blue-600 text-white">
+            Send Invite
+          </button>
+        </div>
+      </form>
+    </Sheet>
   )
 }
 

--- a/apps/web/src/components/MapView.tsx
+++ b/apps/web/src/components/MapView.tsx
@@ -6,9 +6,10 @@ interface Props {
   suggestions: EventItem[]
   onAdd: (e: EventItem) => void
   onReplace: (id: string, alt: EventItem) => void
+  onSelect?: (e: EventItem) => void
 }
 
-export default function MapView({ events, suggestions, onAdd, onReplace }: Props) {
+export default function MapView({ events, suggestions, onAdd, onReplace, onSelect }: Props) {
   const [activeId, setActiveId] = useState<string | null>(null)
   const width = 260
   const height = 180
@@ -29,18 +30,24 @@ export default function MapView({ events, suggestions, onAdd, onReplace }: Props
           />
         ))}
         {events.map((e) => (
-          <div key={e.id} className="absolute" style={{ left: e.position.x, top: e.position.y }}>
-            <div
-              className="w-3 h-3 bg-blue-600 rounded-full -translate-x-1/2 -translate-y-1/2"
-              onClick={() => setActiveId(activeId === e.id ? null : e.id)}
-            />
+          <div
+            key={e.id}
+            className="absolute"
+            style={{ left: e.position.x, top: e.position.y }}
+            onClick={() => {
+              onSelect?.(e)
+              setActiveId(activeId === e.id ? null : e.id)
+            }}
+          >
+            <div className="w-3 h-3 bg-blue-600 rounded-full -translate-x-1/2 -translate-y-1/2" />
             {activeId === e.id && e.alternates && (
               <div className="absolute bg-white border p-1 mt-1 text-sm">
                 {e.alternates.map((alt) => (
                   <button
                     key={alt.id}
                     className="block text-left w-full hover:bg-gray-100 px-2 py-1"
-                    onClick={() => {
+                    onClick={(ev) => {
+                      ev.stopPropagation()
                       onReplace(e.id, alt)
                       setActiveId(null)
                     }}

--- a/apps/web/src/routes/draft.tsx
+++ b/apps/web/src/routes/draft.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
 import { createDraftItinerary } from '../lib/services/itinerary'
 import { useItineraryStore } from '../stores/itineraryStore'
-import { Button, Card } from '../components/ui'
+import { Button, Card, Sheet } from '../components/ui'
 import Calendar from '../components/Calendar'
 import EventList from '../components/EventList'
 import MapView from '../components/MapView'
+import EventDetail from '../components/EventDetail'
+import InviteCollaboratorsModal from '../components/InviteCollaboratorsModal'
 import type { EventItem } from '../lib/types'
 import { suggestionEvents } from '../data'
 
@@ -13,6 +15,8 @@ export default function Draft() {
   const [tab, setTab] = useState<'calendar' | 'list' | 'map'>('calendar')
   const [currentDay] = useState(0)
   const [suggestions, setSuggestions] = useState<EventItem[]>(suggestionEvents)
+  const [selectedEvent, setSelectedEvent] = useState<EventItem | null>(null)
+  const [inviteOpen, setInviteOpen] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -84,7 +88,12 @@ export default function Draft() {
       </div>
 
       {tab === 'calendar' && (
-        <Calendar events={currentEvents} setEvents={setEvents} onReplace={onReplace} />
+        <Calendar
+          events={currentEvents}
+          setEvents={setEvents}
+          onReplace={onReplace}
+          onSelect={setSelectedEvent}
+        />
       )}
       {tab === 'map' && (
         <MapView
@@ -92,6 +101,7 @@ export default function Draft() {
           suggestions={suggestions}
           onAdd={onAdd}
           onReplace={onReplace}
+          onSelect={setSelectedEvent}
         />
       )}
       {tab === 'list' && (
@@ -115,7 +125,11 @@ export default function Draft() {
               </Card>
             ))}
           </div>
-          <EventList events={currentEvents} onReplace={onReplace} />
+          <EventList
+            events={currentEvents}
+            onReplace={onReplace}
+            onSelect={setSelectedEvent}
+          />
         </>
       )}
 
@@ -124,7 +138,23 @@ export default function Draft() {
         <Button variant="outline" onClick={handleSave}>
           Save Trip
         </Button>
+        <Button variant="outline" onClick={() => setInviteOpen(true)}>
+          Invite
+        </Button>
       </div>
+
+      {selectedEvent && (
+        <Sheet open className="p-4 space-y-2">
+          <EventDetail event={selectedEvent} />
+          <Button variant="outline" onClick={() => setSelectedEvent(null)}>
+            Close
+          </Button>
+        </Sheet>
+      )}
+      <InviteCollaboratorsModal
+        isOpen={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- open EventDetail in Draft when a calendar, list, or map event is tapped
- add invite collaborators sheet and button in Draft
- refactor InviteCollaboratorsModal to use Sheet component

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abea381f2c8328967e5a5edecb6dc4