### PR TITLE
Fix missing quote in TripPage import

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,7 +4,7 @@ import Start from './routes/start'
 import Discover from './routes/discover'
 import Draft from './routes/draft'
 import ProfilePage from './pages/ProfilePage'
-import TripPage from './pages/TripPage
+import TripPage from './pages/TripPage'
 import './App.css'
 
 export default function App() {


### PR DESCRIPTION
## Summary
- fix syntax error in `App.tsx` by closing TripPage import string

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68abec2c04488328a38effd4514f43f2