### PR TITLE
fix missing quote in TripPage import

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,7 +4,7 @@ import Start from './routes/start'
 import Discover from './routes/discover'
 import Draft from './routes/draft'
 import ProfilePage from './pages/ProfilePage'
-import TripPage from './pages/TripPage
+import TripPage from './pages/TripPage'
 import './App.css'
 
 export default function App() {


### PR DESCRIPTION
## Summary
- fix missing quote in TripPage import in App.tsx

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68abed4c733483289dc28ecdb83922a1