### PR TITLE
Import toast hook in draft route

### DIFF
--- a/apps/web/src/routes/draft.tsx
+++ b/apps/web/src/routes/draft.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { useToast } from '../components/ToastProvider'
 import { createDraftItinerary } from '../lib/services/itinerary'
 import { saveTrip } from '../lib/services/trip'
 import { useItineraryStore } from '../stores/itineraryStore'


### PR DESCRIPTION
## Summary
- import `useToast` from `ToastProvider` in draft route

## Testing
- `npx tsc -p apps/web/tsconfig.app.json --noEmit` *(fails: Cannot find module './App.css', '@types/jest', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68abee7827c4832893193bcd95dc17ed