### PR TITLE
Refactor itinerary store to track liked and added IDs

### DIFF
--- a/apps/web/src/lib/services/itinerary.ts
+++ b/apps/web/src/lib/services/itinerary.ts
@@ -1,6 +1,6 @@
 export interface CreateDraftItineraryParams {
-  likes: string[]
-  adds: string[]
+  liked: string[]
+  added: string[]
   dates: string[]
   mood: string
 }

--- a/apps/web/src/routes/discover.test.ts
+++ b/apps/web/src/routes/discover.test.ts
@@ -2,23 +2,23 @@ import { MIN_LIKES, MIN_ADDS } from '../lib/constants'
 
 describe('gating logic', () => {
   test('allows build when likes meet threshold', () => {
-    const likes = MIN_LIKES
-    const adds = 0
-    const canBuild = likes >= MIN_LIKES || adds >= MIN_ADDS
+    const liked = Array.from({ length: MIN_LIKES }, (_, i) => `${i}`)
+    const added: string[] = []
+    const canBuild = liked.length >= MIN_LIKES || added.length >= MIN_ADDS
     expect(canBuild).toBe(true)
   })
 
   test('allows build when adds meet threshold', () => {
-    const likes = 0
-    const adds = MIN_ADDS
-    const canBuild = likes >= MIN_LIKES || adds >= MIN_ADDS
+    const liked: string[] = []
+    const added = Array.from({ length: MIN_ADDS }, (_, i) => `${i}`)
+    const canBuild = liked.length >= MIN_LIKES || added.length >= MIN_ADDS
     expect(canBuild).toBe(true)
   })
 
   test('disallows build when thresholds not met', () => {
-    const likes = MIN_LIKES - 1
-    const adds = MIN_ADDS - 1
-    const canBuild = likes >= MIN_LIKES || adds >= MIN_ADDS
+    const liked = Array.from({ length: MIN_LIKES - 1 }, (_, i) => `${i}`)
+    const added = Array.from({ length: MIN_ADDS - 1 }, (_, i) => `${i}`)
+    const canBuild = liked.length >= MIN_LIKES || added.length >= MIN_ADDS
     expect(canBuild).toBe(false)
   })
 })

--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -4,7 +4,7 @@ import {
   type Suggestion,
   type TripCriteria,
 } from '../lib/services/suggestions'
-import { useItineraryStore } from '../stores/itineraryStore'
+import { useItineraryStore, useLikes, useAdds } from '../stores/itineraryStore'
 import { Button, Card } from '../components/ui'
 import { MIN_LIKES, MIN_ADDS } from '../lib/constants'
 import { createDraftItinerary } from '../lib/services/itinerary'
@@ -13,7 +13,9 @@ export default function Discover() {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
   const [index, setIndex] = useState(0)
   const [startX, setStartX] = useState<number | null>(null)
-  const { addLike, addAdd, likes, adds, setDays } = useItineraryStore()
+  const { addLike, addAdd, liked, added, setDays } = useItineraryStore()
+  const likes = useLikes()
+  const adds = useAdds()
   const navigate = useNavigate()
   const location = useLocation()
   const criteria = (location.state || {}) as TripCriteria
@@ -33,7 +35,7 @@ export default function Discover() {
     if (startX === null) return
     const diff = e.changedTouches[0].clientX - startX
     if (diff > 50) {
-      addLike()
+      addLike(current.id)
       next()
     } else if (diff < -50) {
       next()
@@ -42,15 +44,15 @@ export default function Discover() {
   }
 
   const handleAdd = () => {
-    addAdd()
+    addAdd(current.id)
     next()
   }
 
   const canBuild = likes >= MIN_LIKES || adds >= MIN_ADDS
   const buildItinerary = async () => {
     const days = await createDraftItinerary({
-      likes,
-      adds,
+      liked,
+      added,
       dates: ['2025-01-01', '2025-01-02'],
       mood: 'chill',
     })

--- a/apps/web/src/routes/draft.tsx
+++ b/apps/web/src/routes/draft.tsx
@@ -27,8 +27,8 @@ export default function Draft() {
     async function load() {
       if (days.length === 0) {
         const data = await createDraftItinerary({
-          likes: [],
-          adds: [],
+          liked: [],
+          added: [],
           dates: ['2025-01-01', '2025-01-02'],
           mood: 'chill',
         })
@@ -61,8 +61,8 @@ export default function Draft() {
   const handleShuffle = async () => {
     const currentDays = useItineraryStore.getState().days
     const data = await createDraftItinerary({
-      likes: [],
-      adds: [],
+      liked: [],
+      added: [],
       dates: currentDays.map((d) => d.date),
       mood: 'chill',
     })

--- a/apps/web/src/stores/itineraryStore.ts
+++ b/apps/web/src/stores/itineraryStore.ts
@@ -5,18 +5,18 @@ type DayWithLock = ItineraryDay & { locked?: boolean }
 
 interface ItineraryState {
   days: DayWithLock[]
-  likes: number
-  adds: number
+  liked: string[]
+  added: string[]
   setDays: (days: DayWithLock[]) => void
   lockDay: (index: number) => void
-  addLike: () => void
-  addAdd: () => void
+  addLike: (id: string) => void
+  addAdd: (id: string) => void
 }
 
 export const useItineraryStore = create<ItineraryState>((set) => ({
   days: [],
-  likes: 0,
-  adds: 0,
+  liked: [],
+  added: [],
   setDays: (days) => set({ days }),
   lockDay: (index) =>
     set((state) => {
@@ -25,6 +25,9 @@ export const useItineraryStore = create<ItineraryState>((set) => ({
       )
       return { days: updated }
     }),
-  addLike: () => set((state) => ({ likes: state.likes + 1 })),
-  addAdd: () => set((state) => ({ adds: state.adds + 1 })),
+  addLike: (id) => set((state) => ({ liked: [...state.liked, id] })),
+  addAdd: (id) => set((state) => ({ added: [...state.added, id] })),
 }))
+
+export const useLikes = () => useItineraryStore((s) => s.liked.length)
+export const useAdds = () => useItineraryStore((s) => s.added.length)


### PR DESCRIPTION
## Summary
- track liked and added suggestion IDs instead of counts
- pass suggestion IDs through discover interactions and itinerary creation
- update draft generation to accept liked/added arrays

## Testing
- `npm test --prefix apps/web` *(fails: vitest: not found)*
- `npm run lint --prefix apps/web` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68abee7c9b308328a5c60eed8aa03715