### PR TITLE
Normalize city handling for suggestions

### DIFF
--- a/apps/web/src/lib/services/suggestions.ts
+++ b/apps/web/src/lib/services/suggestions.ts
@@ -60,7 +60,7 @@ export async function fetchSuggestions(
   const { city, companions } = criteria
   return SUGGESTIONS.filter(
     (s) =>
-      (!city || s.city === city) &&
+      (!city || s.city.toLowerCase() === city.toLowerCase()) &&
       (companions.length === 0 ||
         s.companions.some((c) => companions.includes(c))),
   ).map(({ id, title, description }) => ({ id, title, description }))

--- a/apps/web/src/stores/tripCriteria.ts
+++ b/apps/web/src/stores/tripCriteria.ts
@@ -25,7 +25,7 @@ export const useTripCriteria = create<TripCriteriaState>((set) => ({
   month: '',
   nights: 1,
   companions: [],
-  setCity: (city) => set({ city }),
+  setCity: (city) => set({ city: city.toLowerCase() }),
   setDateMode: (mode) => set({ dateMode: mode }),
   setStartDate: (date) => set({ startDate: date }),
   setEndDate: (date) => set({ endDate: date }),


### PR DESCRIPTION
## Summary
- Compare cities using case-insensitive matching in `fetchSuggestions`
- Store trip criteria city in lowercase to avoid mismatches

## Testing
- `npm test` *(fails: Missing script "test")*
- `node <<'NODE'
const SUGGESTIONS=[{id:1,title:'Museum Visit',description:'Explore the city museum.',city:'Paris',companions:['Solo','Partner','Family']},{id:2,title:'Local Cafe',description:'Try coffee at the local cafe.',city:'Paris',companions:['Solo','Partner','Friends']},{id:3,title:'City Park',description:'Take a walk in the park.',city:'London',companions:['Solo','Family','Friends']},{id:4,title:'Sushi Night',description:'Enjoy fresh sushi downtown.',city:'Tokyo',companions:['Solo','Partner','Friends']}];
async function fetchSuggestions(criteria){const {city,companions}=criteria;return SUGGESTIONS.filter(s=>(!city||s.city.toLowerCase()===city.toLowerCase())&&(companions.length===0||s.companions.some(c=>companions.includes(c)))).map(({id,title,description})=>({id,title,description}));}
fetchSuggestions({city:'tokyo',companions:[]}).then(r=>console.log(r));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68abf1ed8f208328b6ce11ea67898b56