### PR TITLE
Lower thresholds for itinerary build

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ The A24 travel planner is a conceptual web app that helps travelers craft cinema
 └── README.md
 ```
 
+## Build Itinerary Criteria
+
+For development purposes, the **Build Itinerary** button becomes active once
+you've liked at least **2** suggestions or added **1** suggestion to your
+itinerary. These thresholds are lowered temporarily to accommodate the small
+mock dataset.
+
 ## Future Work
 
 - Connect to real travel APIs for live data

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,2 +1,4 @@
-export const MIN_LIKES = 5;
-export const MIN_ADDS = 3;
+// Temporarily lower gating thresholds so the Build Itinerary CTA
+// can be exercised with the limited mock suggestion dataset.
+export const MIN_LIKES = 2;
+export const MIN_ADDS = 1;

--- a/apps/web/src/routes/discover.test.ts
+++ b/apps/web/src/routes/discover.test.ts
@@ -1,24 +1,27 @@
 import { MIN_LIKES, MIN_ADDS } from '../lib/constants'
 
 describe('gating logic', () => {
-  test('allows build when likes meet threshold', () => {
+  test(`allows build when likes meet threshold (${MIN_LIKES})`, () => {
     const liked = Array(MIN_LIKES).fill('x')
     const added: string[] = []
     const canBuild = liked.length >= MIN_LIKES || added.length >= MIN_ADDS
     expect(canBuild).toBe(true)
   })
 
-  test('allows build when adds meet threshold', () => {
+  test(`allows build when adds meet threshold (${MIN_ADDS})`, () => {
     const liked: string[] = []
     const added = Array(MIN_ADDS).fill('x')
     const canBuild = liked.length >= MIN_LIKES || added.length >= MIN_ADDS
     expect(canBuild).toBe(true)
   })
 
-  test('disallows build when thresholds not met', () => {
+  test(
+    `disallows build when thresholds not met (${MIN_LIKES - 1} likes & ${MIN_ADDS - 1} adds)`,
+    () => {
     const liked = Array(MIN_LIKES - 1).fill('x')
     const added = Array(MIN_ADDS - 1).fill('x')
     const canBuild = liked.length >= MIN_LIKES || added.length >= MIN_ADDS
     expect(canBuild).toBe(false)
-  })
+    },
+  )
 })


### PR DESCRIPTION
## Summary
- Lower `MIN_LIKES` to 2 and `MIN_ADDS` to 1 to enable itinerary building with small mock dataset
- Update gating tests to display new thresholds
- Document the temporary build criteria in README

## Testing
- ⚠️ `npm test` *(failed: vitest not found)*
- ⚠️ `npm run lint` *(failed: Cannot find package '@eslint/js')*
- ✅ `node -e "const MIN_LIKES=2, MIN_ADDS=1; const canBuild=(liked,added)=>liked>=MIN_LIKES || added>=MIN_ADDS; console.log('canBuild with 2 likes:', canBuild(2,0)); console.log('canBuild with 1 add:', canBuild(0,1)); console.log('canBuild with none:', canBuild(0,0));"`


------
https://chatgpt.com/codex/tasks/task_e_68abf1ec478483288b826c7e112722d2