### PR TITLE
feat: add cinematic styling

### DIFF
--- a/apps/web/src/components/InviteCollaboratorsModal.tsx
+++ b/apps/web/src/components/InviteCollaboratorsModal.tsx
@@ -23,8 +23,8 @@ const InviteCollaboratorsModal: React.FC<InviteCollaboratorsModalProps> = ({
   }
 
   return (
-    <Sheet open={isOpen} className="p-4 space-y-4">
-      <h2 className="text-lg font-bold">Invite Collaborators</h2>
+    <Sheet open={isOpen} className="p-4 space-y-4 fade-in">
+      <h2 className="text-lg font-display text-gold">Invite Collaborators</h2>
       <form onSubmit={handleSubmit} className="space-y-2">
         <input
           type="email"
@@ -43,10 +43,10 @@ const InviteCollaboratorsModal: React.FC<InviteCollaboratorsModalProps> = ({
           <option value="edit">Edit</option>
         </select>
         <div className="flex gap-2 justify-end">
-          <button type="button" onClick={onClose} className="px-2 py-1 border rounded">
+          <button type="button" onClick={onClose} className="px-2 py-1 rounded bg-night text-gold">
             Cancel
           </button>
-          <button type="submit" className="px-2 py-1 border rounded bg-blue-600 text-white">
+          <button type="submit" className="px-2 py-1 rounded bg-gold text-night">
             Send Invite
           </button>
         </div>

--- a/apps/web/src/components/MapView.tsx
+++ b/apps/web/src/components/MapView.tsx
@@ -15,8 +15,8 @@ export default function MapView({ events, suggestions, onAdd, onReplace, onSelec
   const height = 180
   const points = events.map((e) => `${e.position.x},${e.position.y}`).join(' ')
   return (
-    <div className="border p-2">
-      <h2 className="font-bold mb-2">Map</h2>
+    <div className="p-2 rounded bg-night text-cream fade-in">
+      <h2 className="mb-2 font-display font-bold text-gold">Map</h2>
       <div className="relative" style={{ width, height }}>
         <svg className="absolute top-0 left-0 pointer-events-none" width={width} height={height}>
           <polyline points={points} stroke="blue" strokeWidth={2} fill="none" />
@@ -41,11 +41,11 @@ export default function MapView({ events, suggestions, onAdd, onReplace, onSelec
           >
             <div className="w-3 h-3 bg-blue-600 rounded-full -translate-x-1/2 -translate-y-1/2" />
             {activeId === e.id && e.alternates && (
-              <div className="absolute bg-white border p-1 mt-1 text-sm">
+              <div className="absolute bg-night text-gold p-1 mt-1 text-sm rounded slide-up">
                 {e.alternates.map((alt) => (
                   <button
                     key={alt.id}
-                    className="block text-left w-full hover:bg-gray-100 px-2 py-1"
+                    className="block text-left w-full px-2 py-1 hover:bg-gold/20"
                     onClick={(ev) => {
                       ev.stopPropagation()
                       onReplace(e.id, alt)

--- a/apps/web/src/components/TripDraft.tsx
+++ b/apps/web/src/components/TripDraft.tsx
@@ -10,13 +10,13 @@ interface Props {
 
 export function TripDraft({ trip, days, readOnly, onSave }: Props) {
   return (
-    <div className="p-4 border rounded">
-      <h2 className="text-xl font-bold">{trip.title}</h2>
+    <div className="p-4 rounded bg-night text-cream fade-in">
+      <h2 className="text-xl font-display text-gold">{trip.title}</h2>
       <p className="mt-2">{trip.description}</p>
       <div className="mt-4 space-y-4">
         {days.map((day) => (
           <div key={day.date} className="space-y-2">
-            <h3 className="font-semibold">{day.date}</h3>
+            <h3 className="font-display text-gold">{day.date}</h3>
             <Calendar
               events={day.events}
               setEvents={() => {}}
@@ -28,7 +28,7 @@ export function TripDraft({ trip, days, readOnly, onSave }: Props) {
       </div>
       {!readOnly && (
         <button
-          className="mt-4 px-4 py-2 bg-blue-500 text-white rounded"
+          className="mt-4 px-4 py-2 bg-gold text-night rounded"
           onClick={onSave}
         >
           Save Trip

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -7,8 +7,8 @@ interface SheetProps extends HTMLAttributes<HTMLDivElement> {
 export function Sheet({ open = false, className = '', ...props }: SheetProps) {
   return (
     <div
-      className={`fixed left-0 right-0 bottom-0 transform rounded-t-lg bg-cream transition-transform sm:p-6 ${
-        open ? 'translate-y-0' : 'translate-y-full'
+      className={`fixed left-0 right-0 bottom-0 transform rounded-t-lg bg-night text-cream transition-transform transition-opacity duration-300 sm:p-6 ${
+        open ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0'
       } ${className}`}
       {...props}
     />

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -6,7 +6,7 @@ const suggestedTrips: Trip[] = [getTrip('4'), getTrip('5'), getTrip('6')];
 
 export default function ProfilePage() {
   return (
-    <div className="p-4 space-y-6">
+    <div className="p-4 space-y-6 fade-in">
       <div className="flex items-center space-x-4">
         <img
           src="https://i.pravatar.cc/100"
@@ -16,23 +16,23 @@ export default function ProfilePage() {
         <p>Traveler and adventurer.</p>
       </div>
       <section>
-        <h2 className="text-lg font-bold mb-2">My Trips</h2>
+        <h2 className="text-lg font-display text-gold mb-2">My Trips</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
           {myTrips.map((t) => (
-            <div key={t.id} className="border p-2 rounded">
-              <h3 className="font-semibold">{t.title}</h3>
+            <div key={t.id} className="p-2 rounded bg-night text-cream fade-in">
+              <h3 className="font-display text-gold">{t.title}</h3>
               <p className="text-sm">{t.description}</p>
             </div>
           ))}
         </div>
       </section>
       <section>
-        <h2 className="text-lg font-bold mb-2">Suggested Trips</h2>
+        <h2 className="text-lg font-display text-gold mb-2">Suggested Trips</h2>
         <div className="overflow-x-auto">
           <div className="flex space-x-4">
             {suggestedTrips.map((t) => (
-              <div key={t.id} className="border p-2 rounded min-w-[200px]">
-                <h3 className="font-semibold">{t.title}</h3>
+              <div key={t.id} className="p-2 rounded min-w-[200px] bg-night text-cream fade-in">
+                <h3 className="font-display text-gold">{t.title}</h3>
                 <p className="text-sm">{t.description}</p>
               </div>
             ))}

--- a/apps/web/src/pages/TripPage.tsx
+++ b/apps/web/src/pages/TripPage.tsx
@@ -7,7 +7,7 @@ export default function TripPage() {
   const trip = getTrip(id ?? '');
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="p-4 space-y-4 fade-in">
       <TripDraft trip={trip} days={trip.itinerary.days} readOnly />
       <div>
         <p className="font-semibold">Shareable link:</p>
@@ -15,7 +15,7 @@ export default function TripPage() {
           type="text"
           readOnly
           value={window.location.href}
-          className="w-full border p-2"
+          className="w-full p-2 bg-night text-cream"
         />
       </div>
     </div>

--- a/apps/web/src/routes/draft.tsx
+++ b/apps/web/src/routes/draft.tsx
@@ -84,7 +84,7 @@ export default function Draft() {
   }
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="p-4 space-y-4 fade-in">
       <div className="flex gap-2">
         <Button variant={tab === 'calendar' ? 'primary' : 'outline'} onClick={() => setTab('calendar')}>
           Calendar
@@ -98,12 +98,14 @@ export default function Draft() {
       </div>
 
       {tab === 'calendar' && (
-        <Calendar
-          events={currentEvents}
-          setEvents={setEvents}
-          onReplace={onReplace}
-          onSelect={setSelectedEvent}
-        />
+        <div className="fade-in">
+          <Calendar
+            events={currentEvents}
+            setEvents={setEvents}
+            onReplace={onReplace}
+            onSelect={setSelectedEvent}
+          />
+        </div>
       )}
       {tab === 'map' && (
         <MapView
@@ -118,7 +120,7 @@ export default function Draft() {
         <>
           <div className="space-y-4">
             {days.map((day, idx) => (
-              <Card key={day.date} className="space-y-2">
+              <Card key={day.date} className="space-y-2 bg-night text-cream fade-in border-0">
                 <h3 className="font-display text-gold">{day.date}</h3>
                 <ul className="list-disc pl-4">
                   {day.events.map((ev) => (

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -40,3 +40,46 @@
     text-align: center;
   }
 }
+
+@layer utilities {
+  .bg-night {
+    background-color: theme('colors.night');
+    color: theme('colors.cream');
+  }
+
+  .text-gold {
+    color: theme('colors.gold');
+  }
+
+  .font-display {
+    font-family: theme('fontFamily.display');
+  }
+
+  .fade-in {
+    animation: fade-in 0.5s ease-out both;
+  }
+
+  .slide-up {
+    animation: slide-up 0.5s ease-out both;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slide-up {
+  from {
+    transform: translateY(1rem);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable utilities and animations for dark theme
- restyle MapView, TripDraft, and profile cards with night backgrounds and gold accents
- introduce fade/slide transitions for pages and modals

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68abf40dc83083288c91ac9714768ae2