### PR TITLE
feat: generate itineraries with taste and city context

### DIFF
--- a/apps/web/src/lib/services/itinerary.ts
+++ b/apps/web/src/lib/services/itinerary.ts
@@ -1,8 +1,19 @@
+interface Location {
+  id: string
+  title: string
+  category: 'breakfast' | 'lunch' | 'dinner' | 'activity'
+  tags: string[]
+  lat: number
+  lng: number
+}
+
 export interface CreateDraftItineraryParams {
   liked: string[]
   added: string[]
   dates: string[]
   mood: string
+  tasteProfile: string[]
+  city: string
 }
 
 export interface ItineraryEvent {
@@ -21,30 +32,170 @@ export interface ItineraryDay {
   events: ItineraryEvent[]
 }
 
+const MOCK_LOCATIONS: Record<string, Location[]> = {
+  paris: [
+    {
+      id: 'cafe-de-flore',
+      title: 'Café de Flore',
+      category: 'breakfast',
+      tags: ['food'],
+      lat: 48.8553,
+      lng: 2.3332,
+    },
+    {
+      id: 'louvre',
+      title: 'Louvre Museum',
+      category: 'activity',
+      tags: ['art'],
+      lat: 48.8606,
+      lng: 2.3376,
+    },
+    {
+      id: 'bistro-lunch',
+      title: 'Le Bistro',
+      category: 'lunch',
+      tags: ['food'],
+      lat: 48.8625,
+      lng: 2.3449,
+    },
+    {
+      id: 'lux-garden',
+      title: 'Luxembourg Gardens',
+      category: 'activity',
+      tags: ['nature'],
+      lat: 48.8462,
+      lng: 2.3371,
+    },
+    {
+      id: 'seine-dinner',
+      title: 'Seine Dinner Cruise',
+      category: 'dinner',
+      tags: ['food'],
+      lat: 48.8584,
+      lng: 2.2945,
+    },
+    {
+      id: 'eiffel',
+      title: 'Eiffel Tower',
+      category: 'activity',
+      tags: ['landmark'],
+      lat: 48.8584,
+      lng: 2.2945,
+    },
+  ],
+}
+
+function getCityLocations(city: string): Location[] {
+  return MOCK_LOCATIONS[city.toLowerCase()] || MOCK_LOCATIONS.paris
+}
+
+const SPEED_KMPH = 5
+
+function toRad(v: number) {
+  return (v * Math.PI) / 180
+}
+
+function distance(a: Location, b: Location): number {
+  const R = 6371
+  const dLat = toRad(b.lat - a.lat)
+  const dLon = toRad(b.lng - a.lng)
+  const lat1 = toRad(a.lat)
+  const lat2 = toRad(b.lat)
+  const h =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) *
+      Math.sin(dLon / 2) * Math.sin(dLon / 2)
+  return 2 * R * Math.asin(Math.sqrt(h))
+}
+
+function travelMinutes(a: Location, b: Location): number {
+  return Math.round((distance(a, b) / SPEED_KMPH) * 60)
+}
+
+function pickNearest(current: Location, list: Location[]): Location | undefined {
+  if (list.length === 0) return undefined
+  let bestIndex = 0
+  let bestDist = distance(current, list[0])
+  for (let i = 1; i < list.length; i++) {
+    const d = distance(current, list[i])
+    if (d < bestDist) {
+      bestDist = d
+      bestIndex = i
+    }
+  }
+  return list.splice(bestIndex, 1)[0]
+}
+
 export async function createDraftItinerary(
   params: CreateDraftItineraryParams,
 ): Promise<ItineraryDay[]> {
-  const { dates } = params
+  const { dates, city, tasteProfile } = params
+  const cityLocations = getCityLocations(city)
 
-  return dates.map((date, idx) => ({
-    date,
-    events: [
-      {
-        id: `${idx}-1`,
-        title: `Breakfast on ${date}`,
-        start: 9 * 60,
-        end: 10 * 60,
-        category: 'food',
-        position: { x: 40, y: 40 },
-      },
-      {
-        id: `${idx}-2`,
-        title: `Museum on ${date}`,
-        start: 11 * 60,
-        end: 12 * 60,
-        category: 'culture',
-        position: { x: 120, y: 80 },
-      },
-    ],
-  }))
+  return dates.map((date) => {
+    const breakfasts = cityLocations.filter((l) => l.category === 'breakfast')
+    const lunches = cityLocations.filter((l) => l.category === 'lunch')
+    const dinners = cityLocations.filter((l) => l.category === 'dinner')
+    let activities = cityLocations.filter(
+      (l) =>
+        l.category === 'activity' &&
+        (tasteProfile.length === 0 ||
+          l.tags.some((t) => tasteProfile.includes(t))),
+    )
+    if (activities.length < 2) {
+      activities = cityLocations.filter((l) => l.category === 'activity')
+    }
+
+    const events: ItineraryEvent[] = []
+    let time = 8 * 60
+
+    const addEvent = (loc: Location, duration: number) => {
+      events.push({
+        id: loc.id,
+        title: loc.title,
+        start: time,
+        end: time + duration,
+        category: loc.category === 'activity' ? loc.tags[0] || 'activity' : 'food',
+        position: { x: loc.lng, y: loc.lat },
+      })
+      time += duration
+    }
+
+    const breakfast = breakfasts.shift()
+    if (breakfast) {
+      addEvent(breakfast, 60)
+    }
+
+    let current = breakfast
+    const firstAct = current ? pickNearest(current, activities) : activities.shift()
+    if (firstAct) {
+      if (current) time += travelMinutes(current, firstAct)
+      current = firstAct
+      addEvent(firstAct, 120)
+    }
+
+    const lunch = current ? pickNearest(current, lunches) : lunches.shift()
+    if (lunch) {
+      if (current) time += travelMinutes(current, lunch)
+      current = lunch
+      addEvent(lunch, 60)
+    }
+
+    const secondAct = current ? pickNearest(current, activities) : activities.shift()
+    if (secondAct) {
+      if (current) time += travelMinutes(current, secondAct)
+      current = secondAct
+      addEvent(secondAct, 120)
+    }
+
+    const dinner = current ? pickNearest(current, dinners) : dinners.shift()
+    if (dinner) {
+      if (current) time += travelMinutes(current, dinner)
+      current = dinner
+      addEvent(dinner, 90)
+    }
+
+    return { date, events }
+  })
 }
+

--- a/apps/web/src/lib/services/suggestions.ts
+++ b/apps/web/src/lib/services/suggestions.ts
@@ -16,6 +16,7 @@ export interface TripCriteria {
   month: string
   nights: number
   companions: string[]
+  tasteProfile: string[]
 }
 
 interface SuggestionRecord extends Suggestion {

--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -70,6 +70,8 @@ export default function Discover() {
       added,
       dates,
       mood,
+      tasteProfile: criteria.tasteProfile || [],
+      city: criteria.city,
     })
     setDays(days)
     setIndex(0)

--- a/apps/web/src/routes/draft.tsx
+++ b/apps/web/src/routes/draft.tsx
@@ -5,6 +5,7 @@ import { useToast } from '../components/ToastProvider'
 import { createDraftItinerary } from '../lib/services/itinerary'
 import { saveTrip } from '../lib/services/trip'
 import { useItineraryStore } from '../stores/itineraryStore'
+import { useTripCriteria } from '../stores/tripCriteria'
 import { Button, Card, Sheet } from '../components/ui'
 import Calendar from '../components/Calendar'
 import EventList from '../components/EventList'
@@ -18,6 +19,7 @@ export default function Draft() {
   const navigate = useNavigate()
   const { toast } = useToast()
   const { days, setDays, lockDay } = useItineraryStore()
+  const { city, tasteProfile } = useTripCriteria()
   const [tab, setTab] = useState<'calendar' | 'list' | 'map'>('calendar')
   const [currentDay] = useState(0)
   const [suggestions, setSuggestions] = useState<EventItem[]>(suggestionEvents)
@@ -32,6 +34,8 @@ export default function Draft() {
           added: [],
           dates: ['2025-01-01', '2025-01-02'],
           mood: 'chill',
+          city,
+          tasteProfile,
         })
         setDays(data)
       }
@@ -61,11 +65,14 @@ export default function Draft() {
 
   const handleShuffle = async () => {
     const currentDays = useItineraryStore.getState().days
+    const { city, tasteProfile } = useTripCriteria.getState()
     const data = await createDraftItinerary({
       liked: [],
       added: [],
       dates: currentDays.map((d) => d.date),
       mood: 'chill',
+      city,
+      tasteProfile,
     })
     const merged = currentDays.map((d, i) => (d.locked ? d : data[i]))
     setDays(merged)

--- a/apps/web/src/routes/start.tsx
+++ b/apps/web/src/routes/start.tsx
@@ -5,6 +5,7 @@ import { useTripCriteria } from '../stores/tripCriteria'
 import { useCitySearch } from '../hooks/useCitySearch'
 
 const companionOptions = ['Solo', 'Partner', 'Family', 'Friends']
+const tasteOptions = ['Foodie', 'Art', 'Nature']
 
 function CityAutocomplete({
   value,
@@ -69,6 +70,8 @@ export default function Start() {
     setNights,
     companions,
     toggleCompanion,
+    tasteProfile,
+    toggleTaste,
   } = useTripCriteria()
 
   const handleSubmit = (e: FormEvent) => {
@@ -97,6 +100,7 @@ export default function Start() {
       month,
       nights,
       companions,
+      tasteProfile,
     }
     navigate('/discover', { state: criteria })
   }
@@ -189,6 +193,20 @@ export default function Start() {
               className="accent-gold"
             />
             {c}
+          </label>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {tasteOptions.map((t) => (
+          <label key={t} className="inline-flex cursor-pointer items-center gap-1 font-display text-sm">
+            <input
+              type="checkbox"
+              checked={tasteProfile.includes(t)}
+              onChange={() => toggleTaste(t)}
+              className="accent-gold"
+            />
+            {t}
           </label>
         ))}
       </div>

--- a/apps/web/src/stores/tripCriteria.ts
+++ b/apps/web/src/stores/tripCriteria.ts
@@ -8,6 +8,7 @@ interface TripCriteriaState {
   month: string
   nights: number
   companions: string[]
+  tasteProfile: string[]
   setCity: (city: string) => void
   setDateMode: (mode: 'range' | 'flex') => void
   setStartDate: (date: string) => void
@@ -15,6 +16,7 @@ interface TripCriteriaState {
   setMonth: (month: string) => void
   setNights: (nights: number) => void
   toggleCompanion: (companion: string) => void
+  toggleTaste: (taste: string) => void
 }
 
 export const useTripCriteria = create<TripCriteriaState>((set) => ({
@@ -25,6 +27,7 @@ export const useTripCriteria = create<TripCriteriaState>((set) => ({
   month: '',
   nights: 1,
   companions: [],
+  tasteProfile: [],
   setCity: (city) => set({ city: city.toLowerCase() }),
   setDateMode: (mode) => set({ dateMode: mode }),
   setStartDate: (date) => set({ startDate: date }),
@@ -36,5 +39,11 @@ export const useTripCriteria = create<TripCriteriaState>((set) => ({
       companions: state.companions.includes(companion)
         ? state.companions.filter((c) => c !== companion)
         : [...state.companions, companion],
+    })),
+  toggleTaste: (taste) =>
+    set((state) => ({
+      tasteProfile: state.tasteProfile.includes(taste)
+        ? state.tasteProfile.filter((t) => t !== taste)
+        : [...state.tasteProfile, taste],
     })),
 }))


### PR DESCRIPTION
## Summary
- expand trip criteria with taste profile and pass taste and city into itinerary creation
- generate daily schedules with mock locations, travel time, and meal/activity slots
- add UI controls to capture taste preferences

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf411d36c8328975e2ceeb367dfad