### PR TITLE
feat: add trip collaborators

### DIFF
--- a/apps/web/src/components/InviteCollaboratorsModal.tsx
+++ b/apps/web/src/components/InviteCollaboratorsModal.tsx
@@ -1,24 +1,29 @@
 import { useState } from 'react'
-import { sendInvite } from '../lib/services/invite'
+import { sendInvite } from '../lib/services/trip'
 import { Sheet } from './ui'
 
 interface InviteCollaboratorsModalProps {
   isOpen: boolean
   onClose: () => void
+  tripId: string
+  onInvited?: () => void
 }
 
 const InviteCollaboratorsModal: React.FC<InviteCollaboratorsModalProps> = ({
   isOpen,
   onClose,
+  tripId,
+  onInvited,
 }) => {
   const [email, setEmail] = useState('')
   const [permission, setPermission] = useState('view')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await sendInvite(email, permission)
+    await sendInvite(tripId, email, permission)
     setEmail('')
     setPermission('view')
+    onInvited?.()
     onClose()
   }
 

--- a/apps/web/src/components/TripDraft.tsx
+++ b/apps/web/src/components/TripDraft.tsx
@@ -6,9 +6,11 @@ interface Props {
   days: ItineraryDay[];
   readOnly?: boolean;
   onSave?: () => void;
+  onInvite?: () => void;
+  onRemoveCollaborator?: (email: string) => void;
 }
 
-export function TripDraft({ trip, days, readOnly, onSave }: Props) {
+export function TripDraft({ trip, days, readOnly, onSave, onInvite, onRemoveCollaborator }: Props) {
   return (
     <div className="p-4 border rounded">
       <h2 className="text-xl font-bold">{trip.title}</h2>
@@ -25,6 +27,38 @@ export function TripDraft({ trip, days, readOnly, onSave }: Props) {
             />
           </div>
         ))}
+      </div>
+      <div className="mt-4">
+        <h3 className="font-semibold">Collaborators</h3>
+        {trip.collaborators.length === 0 ? (
+          <p className="text-sm text-gray-600">No collaborators yet</p>
+        ) : (
+          <ul className="list-disc pl-4 space-y-1">
+            {trip.collaborators.map((c) => (
+              <li key={c.email} className="flex items-center gap-2">
+                <span>
+                  {c.email} ({c.permission})
+                </span>
+                {onRemoveCollaborator && (
+                  <button
+                    className="text-red-600"
+                    onClick={() => onRemoveCollaborator(c.email)}
+                  >
+                    Remove
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+        {onInvite && (
+          <button
+            className="mt-2 px-2 py-1 border rounded"
+            onClick={onInvite}
+          >
+            Invite More
+          </button>
+        )}
       </div>
       {!readOnly && (
         <button

--- a/apps/web/src/lib/mocks/storage.ts
+++ b/apps/web/src/lib/mocks/storage.ts
@@ -13,6 +13,7 @@ const trips: Trip[] = [
         { date: '2025-01-01', events: initialEvents },
       ],
     },
+    collaborators: [],
   },
 ];
 

--- a/apps/web/src/lib/services/invite.ts
+++ b/apps/web/src/lib/services/invite.ts
@@ -1,5 +1,0 @@
-export async function sendInvite(email: string, permission: string) {
-  // Stubbed API call
-  console.log('sendInvite', email, permission)
-  return { success: true }
-}

--- a/apps/web/src/lib/services/trip.ts
+++ b/apps/web/src/lib/services/trip.ts
@@ -1,4 +1,4 @@
-import type { Trip } from '../types'
+import type { Trip, Collaborator } from '../types'
 import { initialEvents } from '../../data'
 import { mockGetTrips, mockSaveTrip } from '../mocks/storage'
 import { STORAGE_ENDPOINT } from '../config'
@@ -14,6 +14,24 @@ export async function saveTrip(trip: Trip): Promise<Trip> {
   return mockSaveTrip(trip)
 }
 
+const collaboratorsStore: Record<string, Collaborator[]> = {}
+
+export async function sendInvite(
+  tripId: string,
+  email: string,
+  permission: Collaborator['permission'],
+) {
+  const collabs = collaboratorsStore[tripId] ?? []
+  collabs.push({ email, permission })
+  collaboratorsStore[tripId] = collabs
+  return { success: true }
+}
+
+export function removeCollaborator(tripId: string, email: string) {
+  const collabs = collaboratorsStore[tripId] ?? []
+  collaboratorsStore[tripId] = collabs.filter((c) => c.email !== email)
+}
+
 export function getTrip(id: string): Trip {
   // mock fetch of trip
   return {
@@ -27,5 +45,6 @@ export function getTrip(id: string): Trip {
         { date: '2025-01-01', events: initialEvents },
       ],
     },
+    collaborators: collaboratorsStore[id] ?? [],
   }
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -25,9 +25,15 @@ export interface Itinerary {
   days: ItineraryDay[]
 }
 
+export interface Collaborator {
+  email: string
+  permission: 'view' | 'edit'
+}
+
 export interface Trip {
   id: string
   title: string
   description: string
   itinerary: Itinerary
+  collaborators: Collaborator[]
 }

--- a/apps/web/src/pages/TripPage.tsx
+++ b/apps/web/src/pages/TripPage.tsx
@@ -1,14 +1,30 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { getTrip } from '../lib/services/trip';
+import { getTrip, removeCollaborator } from '../lib/services/trip';
 import { TripDraft } from '../components/TripDraft';
+import InviteCollaboratorsModal from '../components/InviteCollaboratorsModal';
 
 export default function TripPage() {
   const { id } = useParams<{ id: string }>();
-  const trip = getTrip(id ?? '');
+  const [trip, setTrip] = useState(() => getTrip(id ?? ''));
+  const [inviteOpen, setInviteOpen] = useState(false);
+
+  const refresh = () => setTrip(getTrip(trip.id));
+
+  const handleRemove = (email: string) => {
+    removeCollaborator(trip.id, email);
+    refresh();
+  };
 
   return (
     <div className="p-4 space-y-4">
-      <TripDraft trip={trip} days={trip.itinerary.days} readOnly />
+      <TripDraft
+        trip={trip}
+        days={trip.itinerary.days}
+        readOnly
+        onInvite={() => setInviteOpen(true)}
+        onRemoveCollaborator={handleRemove}
+      />
       <div>
         <p className="font-semibold">Shareable link:</p>
         <input
@@ -18,6 +34,12 @@ export default function TripPage() {
           className="w-full border p-2"
         />
       </div>
+      <InviteCollaboratorsModal
+        isOpen={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+        tripId={trip.id}
+        onInvited={refresh}
+      />
     </div>
   );
 }

--- a/apps/web/src/routes/draft.tsx
+++ b/apps/web/src/routes/draft.tsx
@@ -77,6 +77,7 @@ export default function Draft() {
       title: 'Draft Trip',
       description: 'Draft itinerary',
       itinerary: { id: 'itinerary-draft', suggestions: [], days },
+      collaborators: [],
     }
     await saveTrip(trip)
     toast('Trip saved')
@@ -164,6 +165,7 @@ export default function Draft() {
       <InviteCollaboratorsModal
         isOpen={inviteOpen}
         onClose={() => setInviteOpen(false)}
+        tripId="draft"
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- add collaborator support to Trip model and mock storage
- allow inviting and removing collaborators on Trip pages
- include invite modal wired to trip service

## Testing
- `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68abf41587948328a678b16d03b75970