### PR TITLE
feat: add animated discover background

### DIFF
--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -4,22 +4,33 @@ import {
   type Suggestion,
   type TripCriteria,
 } from '../lib/services/suggestions'
-import { useItineraryStore, useLikes, useAdds } from '../stores/itineraryStore'
+import { useItineraryStore } from '../stores/itineraryStore'
 import { Button, Card } from '../components/ui'
 import { MIN_LIKES, MIN_ADDS } from '../lib/constants'
 import { createDraftItinerary } from '../lib/services/itinerary'
 import { useNavigate, useLocation } from 'react-router-dom'
 export default function Discover() {
-  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+  const [suggestions, setSuggestions] = useState<(Suggestion & { image: string })[]>([])
   const [index, setIndex] = useState(0)
   const [startX, setStartX] = useState<number | null>(null)
+  const [offsetX, setOffsetX] = useState(0)
+  const [pulse, setPulse] = useState(false)
   const { addLike, addAdd, liked, added, setDays } = useItineraryStore()
   const navigate = useNavigate()
   const location = useLocation()
   const criteria = (location.state || {}) as TripCriteria
 
   useEffect(() => {
-    fetchSuggestions(criteria).then(setSuggestions)
+    fetchSuggestions(criteria).then((sugs) => {
+      setSuggestions(
+        sugs.map((s) => ({
+          ...s,
+          image: `https://source.unsplash.com/800x600/?${encodeURIComponent(
+            s.title,
+          )}`,
+        })),
+      )
+    })
   }, [criteria])
 
   const current = suggestions[index]
@@ -29,15 +40,25 @@ export default function Discover() {
     setStartX(e.changedTouches[0].clientX)
   }
 
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (startX === null) return
+    setOffsetX((e.changedTouches[0].clientX - startX) / 4)
+  }
+
   const handleTouchEnd = (e: React.TouchEvent) => {
     if (startX === null || !current) return
     const diff = e.changedTouches[0].clientX - startX
     if (diff > 50) {
+      setPulse(true)
       addLike(String(current.id))
-      next()
+      setTimeout(() => {
+        setPulse(false)
+        next()
+      }, 300)
     } else if (diff < -50) {
       next()
     }
+    setOffsetX(0)
     setStartX(null)
   }
 
@@ -81,14 +102,27 @@ export default function Discover() {
       {current ? (
         <Card
           elevated
+          className='relative h-96 bg-center bg-cover transition-transform'
+          style={{
+            backgroundImage: `url(${current.image})`,
+            transform: `translateX(${offsetX}px)`,
+          }}
           onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
         >
-          <h2 className='text-lg font-display text-gold'>{current.title}</h2>
-          <p className='mt-2'>{current.description}</p>
-          <Button variant='primary' className='mt-4' onClick={handleAdd}>
-            Add to Itinerary
-          </Button>
+          {pulse && (
+            <div className='absolute inset-0 flex items-center justify-center'>
+              <span className='text-6xl text-white animate-ping'>❤</span>
+            </div>
+          )}
+          <div className='absolute bottom-0 w-full bg-gradient-to-t from-black/60 to-transparent p-4'>
+            <h2 className='text-lg font-display text-white'>{current.title}</h2>
+            <p className='mt-2 text-white'>{current.description}</p>
+            <Button variant='primary' className='mt-4' onClick={handleAdd}>
+              Add to Itinerary
+            </Button>
+          </div>
         </Card>
       ) : (
         <p>No more suggestions</p>


### PR DESCRIPTION
## Summary
- show suggestion backgrounds with cover images and gradient overlay
- add swipe parallax effect and like pulse animation

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ac93f5a5e48328875f7de0b6f1d14e