### PR TITLE
refactor: unify button and input styling

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { EventItem } from '../lib/types'
 import { useLongPress } from '../hooks/useLongPress'
+import { Button } from './ui'
 
 interface Props {
   events: EventItem[]
@@ -103,8 +104,9 @@ function EventRow({
       {!readOnly && activeId === e.id && e.alternates && (
         <div className="absolute z-10 bg-white border p-1 top-0 left-full ml-2">
           {e.alternates.map((alt) => (
-            <button
+            <Button
               key={alt.id}
+              variant="ghost"
               className="block text-left px-2 py-1 hover:bg-gray-100"
               onClick={() => {
                 onReplace(e.id, alt)
@@ -112,7 +114,7 @@ function EventRow({
               }}
             >
               {alt.title}
-            </button>
+            </Button>
           ))}
         </div>
       )}

--- a/apps/web/src/components/EventList.tsx
+++ b/apps/web/src/components/EventList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { EventItem } from '../lib/types'
+import { Button } from './ui'
 
 interface Props {
   events: EventItem[]
@@ -24,7 +25,8 @@ export default function EventList({ events, onReplace, onSelect }: Props) {
           </div>
           {e.alternates && (
             <div>
-              <button
+              <Button
+                variant="ghost"
                 className="text-sm text-blue-600"
                 onClick={(ev) => {
                   ev.stopPropagation()
@@ -32,12 +34,13 @@ export default function EventList({ events, onReplace, onSelect }: Props) {
                 }}
               >
                 Replace
-              </button>
+              </Button>
               {openId === e.id && (
                 <div className="mt-1 border p-1">
                   {e.alternates.map((alt) => (
-                    <button
+                    <Button
                       key={alt.id}
+                      variant="ghost"
                       className="block text-left w-full hover:bg-gray-100 px-2 py-1"
                       onClick={(ev) => {
                         ev.stopPropagation()
@@ -46,7 +49,7 @@ export default function EventList({ events, onReplace, onSelect }: Props) {
                       }}
                     >
                       {alt.title}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               )}

--- a/apps/web/src/components/InviteCollaboratorsModal.tsx
+++ b/apps/web/src/components/InviteCollaboratorsModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { sendInvite } from '../lib/services/invite'
-import { Sheet } from './ui'
+import { Sheet, Button } from './ui'
 
 interface InviteCollaboratorsModalProps {
   isOpen: boolean
@@ -32,23 +32,23 @@ const InviteCollaboratorsModal: React.FC<InviteCollaboratorsModalProps> = ({
           onChange={(e) => setEmail(e.target.value)}
           placeholder="Email"
           required
-          className="w-full border p-2 rounded"
+          className="w-full border border-border p-2 rounded focus:outline-none focus:ring-2 focus:ring-gold"
         />
         <select
           value={permission}
           onChange={(e) => setPermission(e.target.value)}
-          className="w-full border p-2 rounded"
+          className="w-full border border-border p-2 rounded focus:outline-none focus:ring-2 focus:ring-gold"
         >
           <option value="view">View</option>
           <option value="edit">Edit</option>
         </select>
         <div className="flex gap-2 justify-end">
-          <button type="button" onClick={onClose} className="px-2 py-1 border rounded">
+          <Button type="button" onClick={onClose} variant="outline" className="px-2 py-1">
             Cancel
-          </button>
-          <button type="submit" className="px-2 py-1 border rounded bg-blue-600 text-white">
+          </Button>
+          <Button type="submit" className="px-2 py-1">
             Send Invite
-          </button>
+          </Button>
         </div>
       </form>
     </Sheet>

--- a/apps/web/src/components/MapView.tsx
+++ b/apps/web/src/components/MapView.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { EventItem } from '../lib/types'
+import { Button } from './ui'
 
 interface Props {
   events: EventItem[]
@@ -43,8 +44,9 @@ export default function MapView({ events, suggestions, onAdd, onReplace, onSelec
             {activeId === e.id && e.alternates && (
               <div className="absolute bg-white border p-1 mt-1 text-sm">
                 {e.alternates.map((alt) => (
-                  <button
+                  <Button
                     key={alt.id}
+                    variant="ghost"
                     className="block text-left w-full hover:bg-gray-100 px-2 py-1"
                     onClick={(ev) => {
                       ev.stopPropagation()
@@ -53,7 +55,7 @@ export default function MapView({ events, suggestions, onAdd, onReplace, onSelec
                     }}
                   >
                     {alt.title}
-                  </button>
+                  </Button>
                 ))}
               </div>
             )}

--- a/apps/web/src/components/TripDraft.tsx
+++ b/apps/web/src/components/TripDraft.tsx
@@ -1,5 +1,6 @@
 import Calendar from './Calendar';
 import type { Trip, ItineraryDay } from '../lib/types';
+import { Button } from './ui';
 
 interface Props {
   trip: Trip;
@@ -27,12 +28,9 @@ export function TripDraft({ trip, days, readOnly, onSave }: Props) {
         ))}
       </div>
       {!readOnly && (
-        <button
-          className="mt-4 px-4 py-2 bg-blue-500 text-white rounded"
-          onClick={onSave}
-        >
+        <Button onClick={onSave} className="mt-4" type="button">
           Save Trip
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 export function Button({ variant = 'primary', className = '', ...props }: ButtonProps) {
   const base = 'inline-flex items-center justify-center rounded font-medium transition-colors'
   const variantStyles = {
-    primary: 'bg-night text-cream hover:bg-gold',
+    primary: 'bg-forest text-cream hover:bg-gold',
     outline: 'border border-slate text-night hover:bg-slate/10',
     ghost: 'text-night hover:bg-slate/10',
   }[variant]

--- a/apps/web/src/pages/TripPage.tsx
+++ b/apps/web/src/pages/TripPage.tsx
@@ -15,7 +15,7 @@ export default function TripPage() {
           type="text"
           readOnly
           value={window.location.href}
-          className="w-full border p-2"
+          className="w-full border border-border p-2 rounded focus:outline-none focus:ring-2 focus:ring-gold"
         />
       </div>
     </div>

--- a/apps/web/src/routes/start.tsx
+++ b/apps/web/src/routes/start.tsx
@@ -30,7 +30,7 @@ function CityAutocomplete({
           onChange(e.target.value)
           setOpen(true)
         }}
-        className="w-full"
+        className="w-full border border-border p-2 rounded focus:outline-none focus:ring-2 focus:ring-gold"
       />
       {open && suggestions.length > 0 && (
         <ul className="absolute z-10 mt-1 w-full max-h-40 overflow-auto rounded border border-slate bg-cream shadow-md">
@@ -142,7 +142,7 @@ export default function Start() {
               type="date"
               value={startDate}
               onChange={(e) => setStartDate(e.target.value)}
-              className="w-full"
+              className="w-full border border-border p-2 rounded focus:outline-none focus:ring-2 focus:ring-gold"
             />
           </div>
           <div className="flex-1">
@@ -151,7 +151,7 @@ export default function Start() {
               type="date"
               value={endDate}
               onChange={(e) => setEndDate(e.target.value)}
-              className="w-full"
+              className="w-full border border-border p-2 rounded focus:outline-none focus:ring-2 focus:ring-gold"
             />
           </div>
         </div>
@@ -163,7 +163,7 @@ export default function Start() {
               type="month"
               value={month}
               onChange={(e) => setMonth(e.target.value)}
-              className="w-full"
+              className="w-full border border-border p-2 rounded focus:outline-none focus:ring-2 focus:ring-gold"
             />
           </div>
           <div className="flex-1">
@@ -173,7 +173,7 @@ export default function Start() {
               min={1}
               value={nights}
               onChange={(e) => setNights(Number(e.target.value))}
-              className="w-full"
+              className="w-full border border-border p-2 rounded focus:outline-none focus:ring-2 focus:ring-gold"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace raw buttons with shared `Button` component and add forest/gold variant
- apply consistent border and focus ring styles to inputs and selects

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching vitest)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac93f8e4d08328abdfed6a0aa79684