### PR TITLE
fix: add invite service alias

### DIFF
--- a/apps/web/src/lib/services/invite.ts
+++ b/apps/web/src/lib/services/invite.ts
@@ -1,0 +1,1 @@
+export { sendInvite } from './trip'


### PR DESCRIPTION
## Summary
- add invite service module re-exporting sendInvite from trip service to satisfy component import

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: various missing type declaration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aca276b88883288ce03cf48361cd96