### PR TITLE
fix: add fallback for night theme color

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -43,7 +43,7 @@
 
 @layer utilities {
   .bg-night {
-    background-color: theme('colors.night');
+    background-color: theme('colors.night', '#1A202C');
     color: theme('colors.cream');
   }
 


### PR DESCRIPTION
## Summary
- avoid build error by adding fallback color to `theme('colors.night')`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68acb62b6b948328b4d0d0f6fef27790