### PR TITLE
remove duplicate globals.css link

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,7 +8,6 @@
       href="https://fonts.googleapis.com/css2?family=Fraunces:wght@500;700&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="/src/styles/globals.css" />
     <title>Vite + React + TS</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- remove globals stylesheet link from index.html

## Testing
- `npm run dev` *(fails: vite not found, install fails with 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68acd30f76348328a7b2eb9075c09a50