### PR TITLE
chore(web): add daisyui plugin

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.1",
+    "daisyui": "^4.0.0"
   }
 }

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,3 +1,5 @@
+import daisyui from 'daisyui';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
@@ -17,5 +19,8 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [daisyui],
+  daisyui: {
+    themes: ['light', 'dark'],
+  },
 };


### PR DESCRIPTION
## Summary
- add DaisyUI as a dev dependency
- enable DaisyUI plugin with light and dark themes in Tailwind config

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/daisyui)*
- `npm run build` *(fails: TS errors and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68afdc39f2f883289bdb8e9eb03d6788